### PR TITLE
English Corrections + Social Media Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@ Sabbath School for Android
 
 [![Travis](https://img.shields.io/travis/Adventech/sabbath-school-android-2.svg)](https://travis-ci.org/Adventech/sabbath-school-android-2) [![GitHub Stars](https://img.shields.io/github/stars/Adventech/sabbath-school-android-2.svg)](https://github.com/Adventech/sabbath-school-android-2/stargazers) [![GitHub Issues](https://img.shields.io/github/issues/Adventech/sabbath-school-android-2.svg)](https://github.com/Adventech/sabbath-school-android-2/issues) [![license](https://img.shields.io/github/license/Adventech/sabbath-school-android-2.svg)](https://github.com/Adventech/sabbath-school-android-2/blob/master/LICENSE.md)
 
-This is Sabbath School for Android by Adventech. Humble attempt to make difference with respect to Sabbath School as entity of Seventh-day Adventist Church!
+This is Sabbath School for Android by Adventech, a humble attempt to make difference with respect to Sabbath School as an entity of Seventh-day Adventist Church!
 
 ## Screenshots
 
 <img src="https://raw.githubusercontent.com/Adventech/sabbath-school-android/master/fastlane/metadata/android/en-US/images/phoneScreenshots/lessons_screen_1499032106305.png" alt="Screenshot" height="500"/> <img src="https://raw.githubusercontent.com/Adventech/sabbath-school-android/master/fastlane/metadata/android/en-US/images/phoneScreenshots/reading_screen_1499032114397.png" height="500"/>
-
-## Features
 
 ## Features
 
@@ -24,12 +22,12 @@ This is Sabbath School for Android by Adventech. Humble attempt to make differen
 - [x] Reading themes 🕶
 - [ ] Progress analytics 📊
 - [ ] List notes & highlights ⭐️
-- [ ] Anroid TV support 📺
+- [ ] Android TV support 📺
 - [ ] Push notifications 🔔
 
 ## How can you help?
 
-- Help us to [translate](https://poeditor.com/join/project/B5QVkjk21J) application or it's content into all the languages in the world!
+- Help us to [translate](https://poeditor.com/join/project/B5QVkjk21J) the application or its content into all the languages in the world!
 - Report bugs or issues
 - Contribute by developing
 
@@ -48,4 +46,3 @@ This is Sabbath School for Android by Adventech. Humble attempt to make differen
 - [Textografo](http://textografo.com) for supporting with incredible diagram-as-a-code tool
 - [POEditor](http://poeditor.com) for supporting with versatile translation platform
 - [JetBrains](http://jetbrains.com) for supporting with all their IDEs for free
-

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ This is Sabbath School for Android by Adventech, a humble attempt to make differ
 ## Socialize
 
 - [Instagram](http://instagram.com/adventech)
+- [Facebook](https://www.facebook.com/shabbatschool/)
+- [Twitter](https://twitter.com/adventech_io)
 
 ## Download
 
-<a href='https://play.google.com/store/apps/details?id=com.cryart.sabbathschool'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="40px"/></a> 
+<a href='https://play.google.com/store/apps/details?id=com.cryart.sabbathschool'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="40px"/></a>
 
 ## Special thanks
 


### PR DESCRIPTION
I looked for Adventech on Facebook and Twitter, and added links to them. 

I linked to  `@shabbatschool` on Facebook instead of `@adventech.io` because the former seems to be more active.