### PR TITLE
Fix login button shadows being cut off

### DIFF
--- a/app/src/main/res/layout/ss_login_buttons.xml
+++ b/app/src/main/res/layout/ss_login_buttons.xml
@@ -47,18 +47,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.7">
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/facebook"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/ss_login_button_social_width"
             android:layout_height="@dimen/ss_login_button_social_height"
-            android:layout_marginHorizontal="@dimen/spacing_micro"
             android:text="@string/ss_login_button_facebook"
             android:textColor="@android:color/white"
             app:backgroundTint="@color/com_facebook_blue"
-            app:cornerRadius="4dp"
+            app:cornerRadius="@dimen/spacing_micro"
             app:icon="@drawable/com_facebook_button_icon"
             app:iconGravity="textStart"
             app:iconTint="@android:color/white"
@@ -66,14 +64,13 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/google"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/ss_login_button_social_width"
             android:layout_height="@dimen/ss_login_button_social_height"
-            android:layout_marginHorizontal="@dimen/spacing_micro"
             android:layout_marginVertical="@dimen/spacing_medium"
             android:text="@string/common_signin_button_text_long"
             android:textColor="@color/ss_gray_3"
             app:backgroundTint="@color/white"
-            app:cornerRadius="4dp"
+            app:cornerRadius="@dimen/spacing_micro"
             app:icon="@drawable/ic_google_logo"
             app:iconGravity="textStart"
             app:iconSize="16dp"
@@ -83,11 +80,12 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/anonymous"
             style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/ss_login_button_social_width"
             android:layout_height="@dimen/ss_login_button_social_height"
             android:text="@string/ss_login_button_anonymous"
             android:textAppearance="@style/TextAppearance.SS.Button"
             android:textColor="?android:attr/textColorPrimary"
+            app:cornerRadius="@dimen/spacing_micro"
             app:textAllCaps="false" />
 
     </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,7 +27,7 @@
     <dimen name="ss_login_app_name_font_size">20sp</dimen>
     <dimen name="ss_login_app_name_margin_top">15dp</dimen>
     <dimen name="ss_login_loading_size">48dp</dimen>
-    <dimen name="ss_login_button_margin_top">5dp</dimen>
     <dimen name="ss_login_button_social_height">56dp</dimen>
+    <dimen name="ss_login_button_social_width">270dp</dimen>
     <dimen name="ss_login_button_social_text_size">14sp</dimen>
 </resources>


### PR DESCRIPTION
Button shadows were being cut off when pressed because of the horizontal margins.
Now setting a fixed button width.