### PR TITLE
Fix quarterly image shared transition

### DIFF
--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/quarterlies/SSQuarterliesAdapter.java
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/quarterlies/SSQuarterliesAdapter.java
@@ -60,7 +60,7 @@ public class SSQuarterliesAdapter extends RecyclerView.Adapter<RecyclerView.View
                 SsQuarterlyItemFeaturedBinding binding = DataBindingUtil.inflate(
                         LayoutInflater.from(parent.getContext()),
                         R.layout.ss_quarterly_item_featured, parent, false);
-                binding.setSsQuarterlyCover(binding.ssQuarterlyItemCover);
+                binding.setSsQuarterlyCover(binding.ssQuarterlyItemCoverCard);
                 viewHolder = new SSQuarterlyViewHolderFeatured(binding);
                 break;
             }
@@ -70,7 +70,7 @@ public class SSQuarterliesAdapter extends RecyclerView.Adapter<RecyclerView.View
                 SsQuarterlyItemNormalBinding binding = DataBindingUtil.inflate(
                         LayoutInflater.from(parent.getContext()),
                         R.layout.ss_quarterly_item_normal, parent, false);
-                binding.setSsQuarterlyCover(binding.ssQuarterlyItemNormalCover);
+                binding.setSsQuarterlyCover(binding.ssQuarterlyItemNormalCoverCard);
                 viewHolder = new SSQuarterlyViewHolderNormal(binding);
                 break;
             }

--- a/features/lessons/src/main/res/layout/ss_quarterly_item_featured.xml
+++ b/features/lessons/src/main/res/layout/ss_quarterly_item_featured.xml
@@ -32,7 +32,7 @@
 
         <variable
             name="ssQuarterlyCover"
-            type="android.widget.ImageView" />
+            type="android.view.View" />
     </data>
 
     <RelativeLayout

--- a/features/lessons/src/main/res/layout/ss_quarterly_item_normal.xml
+++ b/features/lessons/src/main/res/layout/ss_quarterly_item_normal.xml
@@ -32,7 +32,7 @@
 
         <variable
             name="ssQuarterlyCover"
-            type="android.widget.ImageView" />
+            type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -76,6 +76,7 @@
                 android:layout_marginBottom="@dimen/ss_quarterly_item_normal_cover_margin_top"
                 android:onClick="@{() -> viewModel.onReadClick(ssQuarterlyCover)}"
                 android:transitionName="@string/ss_quarterly_cover_transition"
+                app:cardBackgroundColor="@{viewModel.colorPrimary}"
                 app:cardCornerRadius="@dimen/ss_quarterly_item_featured_cover_radius"
                 app:cardElevation="@dimen/spacing_normal">
 


### PR DESCRIPTION
We were sending the imageView instead of the CardView during the shared transition resulting in the corner radius appearing and disappearing during the transition.