### PR TITLE
Fix read screen keyboard input and status bar

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
         const val LIFECYCLE = "2.3.0"
         const val LIFECYCLE_KTX = "2.4.0-alpha01"
         const val LIFECYCLE_EXT = "2.2.0"
-        const val CORE = "1.3.2"
+        const val CORE = "1.5.0-beta03"
         const val FRAGMENT = "1.3.0"
         const val ACTIVITY = "1.2.0"
         const val CONSTRAINT_LAYOUT = "2.0.4"

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/KeyboardInsetsChangeAnimator.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/KeyboardInsetsChangeAnimator.kt
@@ -1,0 +1,65 @@
+package com.cryart.sabbathschool.lessons.ui.readings
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.OnApplyWindowInsetsListener
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+
+/**
+ * Synchronizes keyboard entry & exit animation with the app's layout.
+ */
+class KeyboardInsetsChangeAnimator(
+    private val layout: ViewGroup
+) : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE),
+    OnApplyWindowInsetsListener {
+
+    private lateinit var lastWindowInsets: WindowInsetsCompat
+    private var isKeyboardAnimating = false
+
+    private var isTemporarilyDisabled = false
+
+    override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+        if (!isTemporarilyDisabled && animation.typeMask and ime() != 0) {
+            isKeyboardAnimating = true
+        }
+    }
+
+    override fun onApplyWindowInsets(view: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+        lastWindowInsets = insets
+
+        // When the keyboard isn't animating, the insets are applied immediately.
+        // Otherwise, they're applied during each frame of the animation in onProgress().
+        if (!isKeyboardAnimating) {
+            layout.setPadding(insets)
+        }
+
+        // Stop the insets being dispatched any further into the view hierarchy.
+        return WindowInsetsCompat.CONSUMED
+    }
+
+    override fun onProgress(
+        insets: WindowInsetsCompat,
+        runningAnimations: List<WindowInsetsAnimationCompat>
+    ): WindowInsetsCompat {
+        if (isKeyboardAnimating) {
+            layout.setPadding(insets)
+        }
+        return insets
+    }
+
+    override fun onEnd(animation: WindowInsetsAnimationCompat) {
+        if (isKeyboardAnimating && (animation.typeMask and ime() != 0)) {
+            isKeyboardAnimating = false
+        }
+        isTemporarilyDisabled = false
+    }
+
+    private fun View.setPadding(windowInsets: WindowInsetsCompat) {
+        windowInsets.getInsets(systemBars() or ime()).let {
+            setPadding(it.left, 0, it.right, it.bottom)
+        }
+    }
+}

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
@@ -27,9 +27,14 @@ import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.viewpager.widget.ViewPager
+import app.ss.lessons.data.model.SSLessonInfo
+import app.ss.lessons.data.model.SSRead
+import app.ss.lessons.data.model.SSReadComments
+import app.ss.lessons.data.model.SSReadHighlights
 import coil.load
 import com.cryart.sabbathschool.core.extensions.context.colorPrimary
 import com.cryart.sabbathschool.core.extensions.prefs.SSPrefs
@@ -37,14 +42,10 @@ import com.cryart.sabbathschool.core.misc.SSConstants
 import com.cryart.sabbathschool.core.misc.SSUnzip
 import com.cryart.sabbathschool.core.navigation.AppNavigator
 import com.cryart.sabbathschool.core.navigation.Destination
+import com.cryart.sabbathschool.lessons.BuildConfig
 import com.cryart.sabbathschool.lessons.R
-import app.ss.lessons.data.model.SSLessonInfo
-import app.ss.lessons.data.model.SSReadComments
-import app.ss.lessons.data.model.SSReadHighlights
 import com.cryart.sabbathschool.lessons.databinding.SsReadingActivityBinding
 import com.cryart.sabbathschool.lessons.ui.base.SSBaseActivity
-import app.ss.lessons.data.model.SSRead
-import com.cryart.sabbathschool.lessons.BuildConfig
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageMetadata
 import com.google.firebase.storage.StorageReference
@@ -104,11 +105,15 @@ class SSReadingActivity : SSBaseActivity(), SSReadingViewModel.DataListener, Vie
     }
 
     private fun initUI() {
-        @Suppress("DEPRECATION")
-        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-
         setSupportActionBar(binding.ssReadingAppBar.ssReadingToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        with(binding.ssReadingViewPager) {
+            val insetAnimator = KeyboardInsetsChangeAnimator(this)
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            ViewCompat.setWindowInsetsAnimationCallback(this, insetAnimator)
+            ViewCompat.setOnApplyWindowInsetsListener(this, insetAnimator)
+        }
 
         with(binding.ssReadingAppBar.ssReadingCollapsingToolbar) {
             setCollapsedTitleTextAppearance(R.style.AppThemeAppBarTextStyle)

--- a/features/lessons/src/main/res/layout/ss_reading_activity.xml
+++ b/features/lessons/src/main/res/layout/ss_reading_activity.xml
@@ -30,15 +30,11 @@
             type="com.cryart.sabbathschool.lessons.ui.readings.SSReadingViewModel" />
     </data>
 
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
-
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/ss_reading_coordinator"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
         android:keepScreenOn="true">
 
         <include
@@ -76,5 +72,4 @@
             bind:progressVisibility="@{viewModel.ssLessonLoadingVisibility}" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-    </FrameLayout>
 </layout>


### PR DESCRIPTION
# What did you change:

When we merged #185 we broke the status bar. [screenshot](https://github.com/Adventech/sabbath-school-android/pull/188#issuecomment-833584966).
This change uses the new [WindowInsetsAnimationCompat](https://developer.android.com/reference/androidx/core/view/WindowInsetsAnimationCompat) to adjust the layout when keyboard is visible and also status bar is fixed

# Screenshot/GIFs of this change

![Screenshot_20210506-201602](https://user-images.githubusercontent.com/5994683/117380745-6cead480-aea8-11eb-9689-32278bce4908.jpg)


# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests