### PR TITLE
Shareable quarterly and read lesson web url

### DIFF
--- a/.github/labels_config.yml
+++ b/.github/labels_config.yml
@@ -12,6 +12,8 @@ bible:
   - 'features/bible/*'
 lessons:
   - 'features/lessons/*'
+lessons-data:
+  - 'common/lessons-data/*'
 reader:
   - 'features/reader/*'
 settings:

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(AndroidX.LIFECYCLE_KTX)
     implementation(AndroidX.PREFERENCE)
     implementation(AndroidX.BROWSER)
+    implementation(AndroidX.CORE)
     implementation(AndroidX.DATASTORE_PREFS)
     implementation(Kotlin.COROUTINES)
     implementation(Kotlin.COROUTINES_ANDROID)

--- a/common/core/src/main/java/com/cryart/sabbathschool/core/extensions/context/ContextExt.kt
+++ b/common/core/src/main/java/com/cryart/sabbathschool/core/extensions/context/ContextExt.kt
@@ -28,6 +28,7 @@ import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.app.ShareCompat
 import androidx.core.net.toUri
 import com.cryart.sabbathschool.core.R
 import com.cryart.sabbathschool.core.misc.SSColorTheme
@@ -98,7 +99,14 @@ object ContextHelper {
     fun launchWebUrl(context: Context, url: String) {
         context.launchWebUrl(url)
     }
+}
 
-    @JvmStatic
-    fun isDarkTheme(context: Context): Boolean = context.isDarkTheme()
+fun Context.shareContent(content: String, chooser: String = "") {
+    val shareIntent = ShareCompat.IntentBuilder(this)
+        .setType("text/plain")
+        .setText(content)
+        .intent
+    if (shareIntent.resolveActivity(packageManager) != null) {
+        startActivity(Intent.createChooser(shareIntent, chooser))
+    }
 }

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSLessonInfo.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSLessonInfo.kt
@@ -39,7 +39,7 @@ data class SSLessonInfo(
     )
 
     /**
-     * Replace a Lesson Index of "en-2021-03-04"
+     * Convert a Lesson Index of "en-2021-03-04"
      * To "en/2021-03/04"
      */
     fun shareIndex(): String = lesson.index.mapIndexed { index, c ->

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSLessonInfo.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSLessonInfo.kt
@@ -37,4 +37,16 @@ data class SSLessonInfo(
             it.getValue(SSDay::class.java)
         }
     )
+
+    /**
+     * Replace a Lesson Index of "en-2021-03-04"
+     * To "en/2021-03/04"
+     */
+    fun shareIndex(): String = lesson.index.mapIndexed { index, c ->
+        if ((c == '-' && index < 4) || (c == '-' && index > 7)) {
+            '/'
+        } else {
+            c
+        }
+    }.joinToString("") { it.toString() }
 }

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSQuarterlyInfo.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSQuarterlyInfo.kt
@@ -36,4 +36,10 @@ data class SSQuarterlyInfo(
             it.getValue(SSLesson::class.java)
         }
     )
+
+    /**
+     * Convert a Quarterly index of "en-2021-03"
+     * To "en/2021-03"
+     */
+    fun shareIndex(): String = quarterly.index.replaceFirst("-", "/")
 }

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSRead.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/model/SSRead.kt
@@ -43,4 +43,16 @@ data class SSRead(
         snapshot.child("content").getValue(String::class.java) ?: "",
         snapshot.child("bible").children.mapNotNull { SSBibleVerses(it) }
     )
+
+    /**
+     * Convert a Read index of "en-2021-03-04-02"
+     * To "en/2021-03/04/02"
+     */
+    fun shareIndex(): String = index.mapIndexed { index, c ->
+        if ((c == '-' && index < 4) || (c == '-' && index > 7)) {
+            '/'
+        } else {
+            c
+        }
+    }.joinToString("") { it.toString() }
 }

--- a/common/lessons-data/src/test/java/app/ss/lessons/data/model/ModelTests.kt
+++ b/common/lessons-data/src/test/java/app/ss/lessons/data/model/ModelTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Adventech <info@adventech.io>
+ * Copyright (c) 2021. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,30 +19,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package app.ss.lessons.data.model
 
-import androidx.annotation.Keep
-import com.google.firebase.database.IgnoreExtraProperties
-import java.util.UUID
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
 
-@Keep
-@IgnoreExtraProperties
-data class SSQuarterly(
-    val id: String,
-    val title: String = "",
-    val description: String = "",
-    val human_date: String = "",
-    val start_date: String = "",
-    val end_date: String = "",
-    val cover: String = "",
-    val index: String = "",
-    val group: String = UUID.randomUUID().toString(), // Allows us to easily group quarterlies while maintaining order from api
-    val path: String = "",
-    val full_path: String = "",
-    val lang: String = "",
-    val color_primary: String = "",
-    val color_primary_dark: String = "",
-    val quarterly_name: String = "",
-) {
-    constructor() : this("", color_primary = "")
+class ModelTests {
+
+    @Test
+    fun `should format quarterly info share index`() {
+        val quarterly = SSQuarterly(
+            id = "en-2021-03",
+            index = "en-2021-03",
+        )
+        val quarterlyInfo = SSQuarterlyInfo(quarterly, emptyList())
+
+        quarterlyInfo.shareIndex() shouldBeEqualTo "en/2021-03"
+    }
+
+    @Test
+    fun `should format lesson info share index`() {
+        val lesson = SSLesson(
+            title = "",
+            index = "en-2021-03-04",
+        )
+
+        val lessonInfo = SSLessonInfo(lesson, emptyList())
+
+        lessonInfo.shareIndex() shouldBeEqualTo "en/2021-03/04"
+    }
+
+    @Test
+    fun `should format Read share index`() {
+        val read = SSRead(
+            id = "",
+            index = "en-2021-03-04-02",
+        )
+
+        read.shareIndex() shouldBeEqualTo "en/2021-03/04/02"
+    }
 }

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/base/SSBaseActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/base/SSBaseActivity.kt
@@ -21,14 +21,14 @@
  */
 package com.cryart.sabbathschool.lessons.ui.base
 
-import android.content.Intent
+import android.app.assist.AssistContent
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
 import coil.imageLoader
 import coil.request.ImageRequest
 import coil.size.PixelSize
 import coil.transform.CircleCropTransformation
-import com.cryart.sabbathschool.core.misc.SSConstants
 import com.cryart.sabbathschool.core.ui.SSColorSchemeActivity
 import com.cryart.sabbathschool.lessons.R
 import com.google.firebase.auth.FirebaseAuth
@@ -58,15 +58,10 @@ abstract class SSBaseActivity : SSColorSchemeActivity() {
         } ?: ssToolbar.setNavigationIcon(R.drawable.ic_account_circle_white)
     }
 
-    fun shareApp(message: String?) {
-        val sendIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            type = "text/plain"
-            putExtra(
-                Intent.EXTRA_TEXT,
-                String.format("%s - %s", message, SSConstants.SS_APP_PLAY_STORE_LINK)
-            )
+    override fun onProvideAssistContent(outContent: AssistContent) {
+        super.onProvideAssistContent(outContent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            outContent.webUri = (this as? ShareableScreen)?.getShareWebUri()
         }
-        startActivity(sendIntent)
     }
 }

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/base/ShareableScreen.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/base/ShareableScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Adventech <info@adventech.io>
+ * Copyright (c) 2021. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,30 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package app.ss.lessons.data.model
 
-import androidx.annotation.Keep
-import com.google.firebase.database.IgnoreExtraProperties
-import java.util.UUID
+package com.cryart.sabbathschool.lessons.ui.base
 
-@Keep
-@IgnoreExtraProperties
-data class SSQuarterly(
-    val id: String,
-    val title: String = "",
-    val description: String = "",
-    val human_date: String = "",
-    val start_date: String = "",
-    val end_date: String = "",
-    val cover: String = "",
-    val index: String = "",
-    val group: String = UUID.randomUUID().toString(), // Allows us to easily group quarterlies while maintaining order from api
-    val path: String = "",
-    val full_path: String = "",
-    val lang: String = "",
-    val color_primary: String = "",
-    val color_primary_dark: String = "",
-    val quarterly_name: String = "",
-) {
-    constructor() : this("", color_primary = "")
+import android.net.Uri
+
+interface ShareableScreen {
+
+    fun getShareWebUri(): Uri
 }

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsActivity.kt
@@ -214,7 +214,7 @@ class SSLessonsActivity : SSBaseActivity(), SSLessonsViewModel.DataListener, Sha
     }
 
     override fun getShareWebUri(): Uri {
-        return "${getString(R.string.ss_app_host)}/${ssLessonsViewModel?.ssQuarterlyInfo?.shareIndex() ?: ""}".toWebUri()
+        return "${getString(R.string.ss_app_host)}/${ssLessonsViewModel?.quarterlyShareIndex ?: ""}".toWebUri()
     }
 
     companion object {

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsActivity.kt
@@ -24,6 +24,7 @@ package com.cryart.sabbathschool.lessons.ui.lessons
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -40,6 +41,8 @@ import com.cryart.sabbathschool.core.extensions.arch.observeNonNull
 import com.cryart.sabbathschool.core.extensions.context.colorPrimary
 import com.cryart.sabbathschool.core.extensions.context.colorPrimaryDark
 import com.cryart.sabbathschool.core.extensions.context.colorPrimaryTint
+import com.cryart.sabbathschool.core.extensions.context.shareContent
+import com.cryart.sabbathschool.core.extensions.context.toWebUri
 import com.cryart.sabbathschool.core.extensions.prefs.SSPrefs
 import com.cryart.sabbathschool.core.extensions.view.viewBinding
 import com.cryart.sabbathschool.core.misc.SSColorTheme
@@ -49,13 +52,14 @@ import com.cryart.sabbathschool.core.navigation.Destination
 import com.cryart.sabbathschool.lessons.R
 import com.cryart.sabbathschool.lessons.databinding.SsLessonsActivityBinding
 import com.cryart.sabbathschool.lessons.ui.base.SSBaseActivity
+import com.cryart.sabbathschool.lessons.ui.base.ShareableScreen
 import com.cryart.sabbathschool.lessons.ui.lessons.types.LessonTypesFragment
 import dagger.hilt.android.AndroidEntryPoint
 import hotchemi.android.rate.AppRate
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SSLessonsActivity : SSBaseActivity(), SSLessonsViewModel.DataListener {
+class SSLessonsActivity : SSBaseActivity(), SSLessonsViewModel.DataListener, ShareableScreen {
 
     @Inject
     lateinit var ssPrefs: SSPrefs
@@ -194,7 +198,11 @@ class SSLessonsActivity : SSBaseActivity(), SSLessonsViewModel.DataListener {
                 true
             }
             R.id.ss_lessons_menu_share -> {
-                shareApp(ssLessonsViewModel?.ssQuarterlyInfo?.quarterly?.title)
+                val message = ssLessonsViewModel?.quarterlyTitle ?: ""
+                shareContent(
+                    "$message\n${getShareWebUri()}",
+                    getString(R.string.ss_menu_share_app)
+                )
                 true
             }
             R.id.ss_lessons_menu_settings -> {
@@ -203,6 +211,10 @@ class SSLessonsActivity : SSBaseActivity(), SSLessonsViewModel.DataListener {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun getShareWebUri(): Uri {
+        return "${getString(R.string.ss_app_host)}/${ssLessonsViewModel?.ssQuarterlyInfo?.shareIndex() ?: ""}".toWebUri()
     }
 
     companion object {

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsViewModel.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsViewModel.kt
@@ -51,6 +51,7 @@ internal class SSLessonsViewModel(
     private val mDatabase: DatabaseReference = FirebaseDatabase.getInstance().reference
 
     var ssQuarterlyInfo: SSQuarterlyInfo? = null
+    val quarterlyTitle: String get() = ssQuarterlyInfo?.quarterly?.title ?: ""
 
     val date: String get() = ssQuarterlyInfo?.quarterly?.human_date ?: ""
     val description: String get() = ssQuarterlyInfo?.quarterly?.description ?: ""

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsViewModel.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/SSLessonsViewModel.kt
@@ -51,6 +51,7 @@ internal class SSLessonsViewModel(
     private val mDatabase: DatabaseReference = FirebaseDatabase.getInstance().reference
 
     var ssQuarterlyInfo: SSQuarterlyInfo? = null
+    val quarterlyShareIndex: String get() = ssQuarterlyInfo?.shareIndex() ?: ""
     val quarterlyTitle: String get() = ssQuarterlyInfo?.quarterly?.title ?: ""
 
     val date: String get() = ssQuarterlyInfo?.quarterly?.human_date ?: ""

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
@@ -26,6 +26,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -42,6 +43,8 @@ import app.ss.lessons.data.model.SSReadHighlights
 import coil.load
 import com.cryart.design.theme
 import com.cryart.sabbathschool.core.extensions.context.colorPrimary
+import com.cryart.sabbathschool.core.extensions.context.shareContent
+import com.cryart.sabbathschool.core.extensions.context.toWebUri
 import com.cryart.sabbathschool.core.extensions.coroutines.flow.collectIn
 import com.cryart.sabbathschool.core.extensions.prefs.SSPrefs
 import com.cryart.sabbathschool.core.extensions.view.viewBinding
@@ -54,6 +57,7 @@ import com.cryart.sabbathschool.lessons.BuildConfig
 import com.cryart.sabbathschool.lessons.R
 import com.cryart.sabbathschool.lessons.databinding.SsReadingActivityBinding
 import com.cryart.sabbathschool.lessons.ui.base.SSBaseActivity
+import com.cryart.sabbathschool.lessons.ui.base.ShareableScreen
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageMetadata
 import com.google.firebase.storage.StorageReference
@@ -67,9 +71,7 @@ import java.io.File
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SSReadingActivity :
-    SSBaseActivity(),
-    SSReadingViewModel.DataListener {
+class SSReadingActivity : SSBaseActivity(), SSReadingViewModel.DataListener, ShareableScreen {
 
     @Inject
     lateinit var appNavigator: AppNavigator
@@ -201,7 +203,13 @@ class SSReadingActivity :
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.ss_reading_menu_share -> {
-                shareApp(title as String?)
+                val position = binding.ssReadingViewPager.currentItem
+                val readTitle = readingViewAdapter.getReadAt(position)?.title ?: ""
+                val message = "${ssReadingViewModel.lessonTitle} - $readTitle"
+                shareContent(
+                    "$message\n${getShareWebUri()}",
+                    getString(R.string.ss_menu_share_app)
+                )
                 true
             }
             R.id.ss_reading_menu_suggest_edit -> {
@@ -283,6 +291,13 @@ class SSReadingActivity :
             readingViewAdapter.readingOptions = displayOptions
             ssReadingViewModel.onSSReadingDisplayOptions(displayOptions)
         }
+    }
+
+    override fun getShareWebUri(): Uri {
+        val position = binding.ssReadingViewPager.currentItem
+        val readIndex = readingViewAdapter.getReadAt(position)?.shareIndex()
+
+        return "${getString(R.string.ss_app_host)}/${readIndex ?: ""}".toWebUri()
     }
 
     companion object {

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
@@ -94,6 +94,7 @@ class SSReadingViewModel(
     private var ssReadsLoadedCounter = 0
     private var ssReadsDownloaded = false
     private var highlightId = 0
+    val lessonTitle: String get() = ssLessonInfo?.lesson?.title ?: ""
     val ssLessonLoadingVisibility = ObservableInt(View.INVISIBLE)
     val ssLessonOfflineStateVisibility = ObservableInt(View.INVISIBLE)
     val ssLessonErrorStateVisibility = ObservableInt(View.INVISIBLE)


### PR DESCRIPTION
# What did you change:

Generate Share Url for quarterly and Read Lesson screen

Example:
**Quarterly** >> https://sabbath-school.adventech.io/en/2021-03
**Read Lesson** >> https://sabbath-school.adventech.io/en/2021-03/04/04

Closes #214 

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [x] Automated (unit/ui) tests
- [x] Manual tests