### PR TITLE
Retain user comments and highlights

### DIFF
--- a/buildSrc/src/main/kotlin/BuildAndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildAndroidConfig.kt
@@ -11,8 +11,8 @@ object BuildAndroidConfig {
 
     object Version {
         private const val MAJOR = 4
-        private const val MINOR = 7
-        private const val PATCH = 2
+        private const val MINOR = 8
+        private const val PATCH = 0
 
         const val name = "$MAJOR.$MINOR.$PATCH"
     }

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/repository/lessons/LessonsRepository.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/repository/lessons/LessonsRepository.kt
@@ -25,6 +25,8 @@ package app.ss.lessons.data.repository.lessons
 import app.ss.lessons.data.model.PdfAnnotations
 import app.ss.lessons.data.model.SSLessonInfo
 import app.ss.lessons.data.model.SSRead
+import app.ss.lessons.data.model.SSReadComments
+import app.ss.lessons.data.model.SSReadHighlights
 import app.ss.lessons.data.model.TodayData
 import app.ss.lessons.data.model.WeekData
 import com.cryart.sabbathschool.core.response.Resource
@@ -43,4 +45,8 @@ interface LessonsRepository {
     fun saveAnnotations(lessonIndex: String, pdfId: String, annotations: List<PdfAnnotations>)
 
     suspend fun getAnnotations(lessonIndex: String, pdfId: String): Flow<Resource<List<PdfAnnotations>>>
+
+    suspend fun saveComments(comments: SSReadComments)
+
+    suspend fun saveHighlights(highlights: SSReadHighlights)
 }

--- a/common/lessons-data/src/main/java/app/ss/lessons/data/repository/lessons/LessonsRepositoryImpl.kt
+++ b/common/lessons-data/src/main/java/app/ss/lessons/data/repository/lessons/LessonsRepositoryImpl.kt
@@ -31,9 +31,17 @@ import app.ss.lessons.data.model.SSLessonInfo
 import app.ss.lessons.data.model.SSQuarterly
 import app.ss.lessons.data.model.SSQuarterlyInfo
 import app.ss.lessons.data.model.SSRead
+import app.ss.lessons.data.model.SSReadComments
+import app.ss.lessons.data.model.SSReadHighlights
 import app.ss.lessons.data.model.TodayData
 import app.ss.lessons.data.model.WeekData
 import app.ss.lessons.data.model.WeekDay
+import app.ss.storage.db.dao.ReadCommentsDao
+import app.ss.storage.db.dao.ReadHighlightsDao
+import app.ss.storage.db.entity.Comment
+import app.ss.storage.db.entity.ReadCommentsEntity
+import app.ss.storage.db.entity.ReadHighlightsEntity
+import com.cryart.sabbathschool.core.extensions.coroutines.DispatcherProvider
 import com.cryart.sabbathschool.core.extensions.prefs.SSPrefs
 import com.cryart.sabbathschool.core.misc.DateHelper.formatDate
 import com.cryart.sabbathschool.core.misc.DateHelper.parseDate
@@ -45,6 +53,7 @@ import com.google.firebase.database.ktx.getValue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import org.joda.time.DateTime
 import timber.log.Timber
 import javax.inject.Inject
@@ -54,7 +63,10 @@ import javax.inject.Singleton
 internal class LessonsRepositoryImpl @Inject constructor(
     private val firebaseDatabase: FirebaseDatabase,
     private val firebaseAuth: FirebaseAuth,
-    private val ssPrefs: SSPrefs
+    private val ssPrefs: SSPrefs,
+    private val readCommentsDao: ReadCommentsDao,
+    private val readHighlightsDao: ReadHighlightsDao,
+    private val dispatcherProvider: DispatcherProvider,
 ) : LessonsRepository {
 
     private val firebaseRef = firebaseDatabase.reference.apply { keepSynced(true) }
@@ -263,5 +275,23 @@ internal class LessonsRepositoryImpl @Inject constructor(
                 }
             }
         }
+    }
+
+    override suspend fun saveComments(comments: SSReadComments) = withContext(dispatcherProvider.io) {
+        readCommentsDao.insertItem(
+            ReadCommentsEntity(
+                readIndex = comments.readIndex,
+                comments = comments.comments.map { Comment(it.elementId, it.comment) }
+            )
+        )
+    }
+
+    override suspend fun saveHighlights(highlights: SSReadHighlights) = withContext(dispatcherProvider.io) {
+        readHighlightsDao.insertItem(
+            ReadHighlightsEntity(
+                readIndex = highlights.readIndex,
+                highlights = highlights.highlights
+            )
+        )
     }
 }

--- a/common/storage/build.gradle.kts
+++ b/common/storage/build.gradle.kts
@@ -22,6 +22,9 @@
 
 import dependencies.Dependencies.Hilt
 import dependencies.Dependencies.AndroidX.Room
+import dependencies.Dependencies.Square.Moshi
+import extensions.implementation
+import extensions.kapt
 
 plugins {
     id(BuildPlugins.Android.LIBRARY)
@@ -62,4 +65,7 @@ dependencies {
     implementation(Room.runtime)
     implementation(Room.ktx)
     kapt(Room.compiler)
+
+    implementation(Moshi.kotlin)
+    kapt(Moshi.codegen)
 }

--- a/common/storage/schemas/app.ss.storage.db.SabbathSchoolDatabase/4.json
+++ b/common/storage/schemas/app.ss.storage.db.SabbathSchoolDatabase/4.json
@@ -1,0 +1,160 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "4fce832e88618dc12a17b977bec01b47",
+    "entities": [
+      {
+        "tableName": "audios",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artist` TEXT NOT NULL, `image` TEXT NOT NULL, `imageRatio` TEXT NOT NULL, `src` TEXT NOT NULL, `target` TEXT NOT NULL, `targetIndex` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageRatio",
+            "columnName": "imageRatio",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "src",
+            "columnName": "src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetIndex",
+            "columnName": "targetIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "languages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`code` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`code`))",
+        "fields": [
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "code"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`readIndex` TEXT NOT NULL, `comments` TEXT NOT NULL, PRIMARY KEY(`readIndex`))",
+        "fields": [
+          {
+            "fieldPath": "readIndex",
+            "columnName": "readIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comments",
+            "columnName": "comments",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "readIndex"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "highlights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`readIndex` TEXT NOT NULL, `highlights` TEXT NOT NULL, PRIMARY KEY(`readIndex`))",
+        "fields": [
+          {
+            "fieldPath": "readIndex",
+            "columnName": "readIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlights",
+            "columnName": "highlights",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "readIndex"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4fce832e88618dc12a17b977bec01b47')"
+    ]
+  }
+}

--- a/common/storage/src/main/java/app/ss/storage/db/Converters.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/Converters.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.storage.db
+
+import androidx.room.TypeConverter
+import app.ss.storage.db.entity.Comment
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.lang.reflect.Type
+
+internal object Converters {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val commentsAdapter: JsonAdapter<List<Comment>> by lazy {
+        val listDataType: Type = Types.newParameterizedType(List::class.java, Comment::class.java)
+        moshi.adapter(listDataType)
+    }
+
+    @TypeConverter
+    fun toComments(value: String?): List<Comment>? = value?.let { jsonString ->
+        commentsAdapter.fromJson(jsonString)
+    }
+
+    @TypeConverter
+    fun fromComments(comments: List<Comment>?): String? = commentsAdapter.toJson(comments)
+}

--- a/common/storage/src/main/java/app/ss/storage/db/SabbathSchoolDatabase.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/SabbathSchoolDatabase.kt
@@ -27,27 +27,40 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import app.ss.storage.db.dao.AudioDao
 import app.ss.storage.db.dao.LanguagesDao
+import app.ss.storage.db.dao.ReadCommentsDao
+import app.ss.storage.db.dao.ReadHighlightsDao
 import app.ss.storage.db.entity.AudioFileEntity
 import app.ss.storage.db.entity.LanguageEntity
+import app.ss.storage.db.entity.ReadCommentsEntity
+import app.ss.storage.db.entity.ReadHighlightsEntity
 
 @Database(
     entities = [
         AudioFileEntity::class,
-        LanguageEntity::class
+        LanguageEntity::class,
+        ReadCommentsEntity::class,
+        ReadHighlightsEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
     autoMigrations = [
-        AutoMigration(from = 2, to = 3)
+        AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4)
     ]
 )
+@TypeConverters(Converters::class)
 internal abstract class SabbathSchoolDatabase : RoomDatabase() {
 
     abstract fun audioDao(): AudioDao
 
     abstract fun languagesDao(): LanguagesDao
+
+    abstract fun readCommentsDao(): ReadCommentsDao
+
+    abstract fun readHighlightsDao(): ReadHighlightsDao
 
     companion object {
         private const val DATABASE_NAME = "sabbath_school_db"

--- a/common/storage/src/main/java/app/ss/storage/db/dao/ReadCommentsDao.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/dao/ReadCommentsDao.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.storage.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import app.ss.storage.db.entity.ReadCommentsEntity
+
+@Dao
+interface ReadCommentsDao : BaseDao<ReadCommentsEntity> {
+
+    @Query("SELECT * FROM comments WHERE readIndex = :readIndex")
+    fun get(readIndex: String): ReadCommentsEntity?
+}

--- a/common/storage/src/main/java/app/ss/storage/db/dao/ReadHighlightsDao.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/dao/ReadHighlightsDao.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.storage.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import app.ss.storage.db.entity.ReadHighlightsEntity
+
+@Dao
+interface ReadHighlightsDao : BaseDao<ReadHighlightsEntity> {
+
+    @Query("SELECT * FROM highlights WHERE readIndex = :readIndex")
+    fun get(readIndex: String): ReadHighlightsEntity?
+}

--- a/common/storage/src/main/java/app/ss/storage/db/entity/ReadCommentsEntity.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/entity/ReadCommentsEntity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.storage.db.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "comments")
+data class ReadCommentsEntity(
+    @PrimaryKey val readIndex: String,
+    val comments: List<Comment>
+)
+
+data class Comment(
+    val elementId: String,
+    var comment: String
+)

--- a/common/storage/src/main/java/app/ss/storage/db/entity/ReadHighlightsEntity.kt
+++ b/common/storage/src/main/java/app/ss/storage/db/entity/ReadHighlightsEntity.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.storage.db.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "highlights")
+data class ReadHighlightsEntity(
+    @PrimaryKey val readIndex: String,
+    var highlights: String
+)

--- a/common/storage/src/main/java/app/ss/storage/di/StorageModule.kt
+++ b/common/storage/src/main/java/app/ss/storage/di/StorageModule.kt
@@ -26,6 +26,8 @@ import android.content.Context
 import app.ss.storage.db.SabbathSchoolDatabase
 import app.ss.storage.db.dao.AudioDao
 import app.ss.storage.db.dao.LanguagesDao
+import app.ss.storage.db.dao.ReadCommentsDao
+import app.ss.storage.db.dao.ReadHighlightsDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -41,11 +43,25 @@ object StorageModule {
     @Singleton
     fun provideAudioDao(
         @ApplicationContext context: Context,
-    ): AudioDao = SabbathSchoolDatabase.getInstance(context).audioDao()
+    ): AudioDao = context.database().audioDao()
 
     @Provides
     @Singleton
     fun provideLanguagesDao(
         @ApplicationContext context: Context,
-    ): LanguagesDao = SabbathSchoolDatabase.getInstance(context).languagesDao()
+    ): LanguagesDao = context.database().languagesDao()
+
+    @Provides
+    @Singleton
+    fun provideReadCommentsDao(
+        @ApplicationContext context: Context,
+    ): ReadCommentsDao = context.database().readCommentsDao()
+
+    @Provides
+    @Singleton
+    fun provideReadHighlightsDao(
+        @ApplicationContext context: Context,
+    ): ReadHighlightsDao = context.database().readHighlightsDao()
+
+    private fun Context.database(): SabbathSchoolDatabase = SabbathSchoolDatabase.getInstance(this)
 }

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
@@ -86,6 +86,9 @@ class SSReadingActivity : SlidingActivity(), SSReadingViewModel.DataListener, Sh
     @Inject
     lateinit var pdfReader: PdfReader
 
+    @Inject
+    lateinit var readingVmFactory: SSReadingViewModel.Factory
+
     private val binding by viewBinding(SsReadingActivityBinding::inflate)
     private val latestReaderArtifactRef: StorageReference = FirebaseStorage.getInstance()
         .reference.child(SSConstants.SS_READER_ARTIFACT_NAME)
@@ -116,11 +119,11 @@ class SSReadingActivity : SlidingActivity(), SSReadingViewModel.DataListener, Sh
 
         ViewTreeLifecycleOwner.set(binding.root, this)
         if (!this::ssReadingViewModel.isInitialized) {
-            ssReadingViewModel = SSReadingViewModel(
-                this,
-                this,
-                lessonIndex,
-                binding
+            ssReadingViewModel = readingVmFactory.create(
+                lessonIndex = lessonIndex,
+                dataListener = this,
+                ssReadingActivityBinding = binding,
+                activity = this
             )
         }
 

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
@@ -44,6 +44,7 @@ import app.ss.lessons.data.model.SSRead
 import app.ss.lessons.data.model.SSReadComments
 import app.ss.lessons.data.model.SSReadHighlights
 import app.ss.lessons.data.model.SSSuggestion
+import app.ss.lessons.data.repository.lessons.LessonsRepository
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.input.input
 import com.cryart.sabbathschool.bible.SSBibleVersesActivity
@@ -66,23 +67,30 @@ import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.joda.time.DateTime
 import ru.beryukhov.reactivenetwork.ReactiveNetwork
 import ru.beryukhov.reactivenetwork.internet.observing.InternetObservingSettings
 import timber.log.Timber
-import java.util.ArrayList
 
-class SSReadingViewModel(
-    private val context: Context,
-    private val dataListener: DataListener,
-    private val ssLessonIndex: String,
-    private val ssReadingActivityBinding: SsReadingActivityBinding,
-) : SSReadingView.ContextMenuCallback, SSReadingView.HighlightsCommentsCallback {
+class SSReadingViewModel @AssistedInject constructor(
+    private val lessonsRepository: LessonsRepository,
+    @Assisted private val ssLessonIndex: String,
+    @Assisted private val dataListener: DataListener,
+    @Assisted private val ssReadingActivityBinding: SsReadingActivityBinding,
+    @Assisted private val activity: FragmentActivity,
+) : SSReadingView.ContextMenuCallback, SSReadingView.HighlightsCommentsCallback, CoroutineScope by MainScope() {
+
+    private val context: Context = activity
+
     private val ssFirebaseAuth: FirebaseAuth = FirebaseAuth.getInstance()
     private val userUuid = ssFirebaseAuth.currentUser?.uid ?: ""
     private val mDatabase = FirebaseDatabase.getInstance().reference.apply {
@@ -229,6 +237,8 @@ class SSReadingViewModel(
                 override fun onDataChange(dataSnapshot: DataSnapshot) {
                     val ssReadHighlights = dataSnapshot.getValue(SSReadHighlights::class.java) ?: SSReadHighlights(dayIndex)
                     downloadComments(dayIndex, index, ssReadHighlights)
+
+                    launch { lessonsRepository.saveHighlights(ssReadHighlights) }
                 }
 
                 override fun onCancelled(databaseError: DatabaseError) {
@@ -245,6 +255,8 @@ class SSReadingViewModel(
                 override fun onDataChange(dataSnapshot: DataSnapshot) {
                     val ssReadComments = SSReadComments(dataSnapshot, dayIndex)
                     downloadRead(dayIndex, index, ssReadHighlights, ssReadComments)
+
+                    launch { lessonsRepository.saveComments(ssReadComments) }
                 }
 
                 override fun onCancelled(databaseError: DatabaseError) {
@@ -358,6 +370,8 @@ class SSReadingViewModel(
             SSConstants.SS_EVENT_TEXT_HIGHLIGHTED,
             hashMapOf(SSConstants.SS_EVENT_PARAM_READ_INDEX to ssReads[ssReadingActivityBinding.ssReadingViewPager.currentItem].index)
         )
+
+        launch { lessonsRepository.saveHighlights(ssReadHighlights) }
     }
 
     override fun onCommentsReceived(ssReadComments: SSReadComments) {
@@ -370,6 +384,8 @@ class SSReadingViewModel(
             SSConstants.SS_EVENT_COMMENT_CREATED,
             hashMapOf(SSConstants.SS_EVENT_PARAM_READ_INDEX to ssReads[ssReadingActivityBinding.ssReadingViewPager.currentItem].index)
         )
+
+        launch { lessonsRepository.saveComments(ssReadComments) }
     }
 
     override fun onVerseClicked(verse: String) = verseClickWithDebounce(verse)
@@ -475,6 +491,16 @@ class SSReadingViewModel(
     fun reloadContent() {
         loadLessonInfo()
         checkConnection()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            lessonIndex: String,
+            dataListener: DataListener,
+            ssReadingActivityBinding: SsReadingActivityBinding,
+            activity: FragmentActivity
+        ): SSReadingViewModel
     }
 
     companion object {

--- a/libraries/test_utils/src/main/java/com/cryart/sabbathschool/test/di/repository/FakeLessonsRepository.kt
+++ b/libraries/test_utils/src/main/java/com/cryart/sabbathschool/test/di/repository/FakeLessonsRepository.kt
@@ -3,6 +3,8 @@ package com.cryart.sabbathschool.test.di.repository
 import app.ss.lessons.data.model.PdfAnnotations
 import app.ss.lessons.data.model.SSLessonInfo
 import app.ss.lessons.data.model.SSRead
+import app.ss.lessons.data.model.SSReadComments
+import app.ss.lessons.data.model.SSReadHighlights
 import app.ss.lessons.data.model.TodayData
 import app.ss.lessons.data.model.WeekData
 import app.ss.lessons.data.repository.lessons.LessonsRepository
@@ -35,4 +37,8 @@ class FakeLessonsRepository @Inject constructor() : LessonsRepository {
     override suspend fun getAnnotations(lessonIndex: String, pdfId: String): Flow<Resource<List<PdfAnnotations>>> {
         return emptyFlow()
     }
+
+    override suspend fun saveComments(comments: SSReadComments) {}
+
+    override suspend fun saveHighlights(highlights: SSReadHighlights) {}
 }


### PR DESCRIPTION
# What did you change:

- Saving user comments and highlights to local database so that they don’t lose them when they receive the next update that removes firebase database
- Only data from the active lesson they’re reading will be saved

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests