### PR TITLE
Update dependency versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ androidx-annotations = "1.5.0"
 androidx-appcompat = "1.6.0"
 androidx-browser = "1.4.0"
 androidx-compose-bom = "2023.01.00"
-composeCompiler = "1.3.2"
+composeCompiler = "1.4.0"
 # Used in sgp. @keep same as kotlin
-composeCompilerKotlinVersion = "1.7.20"
+composeCompilerKotlinVersion = "1.8.0"
 androidx-compose-constraintlayout = "1.0.1"
 androidx-compose-material3 = "1.0.1"
 androidx-constraintlayout = "2.1.4"
@@ -47,13 +47,13 @@ joda-android = "2.12.1.1"
 joda-time = "2.12.2"
 jvmTarget = "11"
 # @keep same as composeCompilerKotlinVersion
-kotlin = "1.7.20"
+kotlin = "1.8.0"
 kotlin-coroutines = "1.6.4"
 markwon = "4.6.2"
 material-dialogs = "3.3.0"
 # @keep this version
 pdfkit = "8.5.0"
-sgp = "0.3.8"
+sgp = "0.4.2"
 snapper = "0.3.0"
 spotless = "6.13.0"
 square-moshi = "1.14.0"
@@ -66,6 +66,7 @@ test-androidx-espresso = "3.5.1"
 test-androidx-benchmark = "1.2.0-alpha09"
 test-androidx-benchmark-macro = "1.1.1"
 test-androidx-ext = "1.1.5"
+test-androidx-runner = "1.5.2"
 test-androidx-uiautomator = "2.2.0"
 test-junit = "4.13.2"
 test-kluent = "1.72"
@@ -167,7 +168,7 @@ test-androidx-espresso-core = { module = "androidx.test.espresso:espresso-core",
 test-androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "test-androidx-espresso" }
 test-androidx-ext = { module = "androidx.test.ext:junit", version.ref = "test-androidx-ext" }
 test-androidx-rules = { module = "androidx.test:rules", version.ref = "test-androidx" }
-test-androidx-runner = { module = "androidx.test:runner", version.ref = "test-androidx" }
+test-androidx-runner = { module = "androidx.test:runner", version.ref = "test-androidx-runner" }
 test-androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "test-androidx-uiautomator" }
 test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 test-google-hilt = { module = "com.google.dagger:hilt-android-testing", version.ref = "google-hilt" }


### PR DESCRIPTION
# What did you change:

Bump dependency versions:

- compose compiler version to 1.4.0
- kotlin to 1.8.0
- sgp to 0.4.2
- test androidx runner to 1.5.2

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests