### PR TITLE
Use custom view for reading appBar title

### DIFF
--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
@@ -233,6 +233,7 @@ class SSReadingActivity : SlidingActivity(), SSReadingViewModel.DataListener, Sh
     private fun setPageTitleAndSubtitle(title: String, subTitle: String) {
         binding.ssReadingAppBar.apply {
             ssReadingCollapsingToolbar.title = title
+            ssReadingExpandedTitle.text = title
             ssCollapsingToolbarSubtitle.text = subTitle
             ssCollapsingToolbarBackdrop.contentDescription = title
         }
@@ -314,9 +315,7 @@ class SSReadingActivity : SlidingActivity(), SSReadingViewModel.DataListener, Sh
             readPosition: String? = null
         ): Intent = Intent(context, SSReadingActivity::class.java).apply {
             putExtra(SSConstants.SS_LESSON_INDEX_EXTRA, lessonIndex)
-            readPosition?.let {
-                putExtra(SSConstants.SS_READ_POSITION_EXTRA, readPosition)
-            }
+            putExtra(SSConstants.SS_READ_POSITION_EXTRA, readPosition)
         }
     }
 }

--- a/features/lessons/src/main/res/layout/ss_reading_app_bar.xml
+++ b/features/lessons/src/main/res/layout/ss_reading_app_bar.xml
@@ -54,8 +54,8 @@
             app:layout_scrollFlags="scroll|enterAlwaysCollapsed|enterAlways"
             app:maxLines="2"
             app:statusBarScrim="@{viewModel.secondaryColor}"
-            app:toolbarId="@+id/ss_reading_toolbar"
-            tools:title="How to Get Out of Debt">
+            app:titleCollapseMode="fade"
+            app:toolbarId="@+id/ss_reading_toolbar">
 
             <ImageView
                 android:id="@+id/ss_collapsing_toolbar_backdrop"
@@ -67,22 +67,39 @@
                 app:layout_collapseMode="parallax"
                 tools:src="?attr/colorAccent" />
 
-            <TextView
-                android:id="@+id/ss_collapsing_toolbar_subtitle"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentTop="true"
                 android:layout_gravity="bottom"
-                android:layout_marginHorizontal="@dimen/ss_reading_toolbar_title_margin_left"
                 android:layout_marginBottom="@dimen/spacing_medium"
-                android:fontFamily="@font/lato_bold"
-                android:maxLines="1"
-                android:textAllCaps="true"
-                android:textColor="@color/ss_color_secondary_lighter"
-                android:textSize="@dimen/ss_reading_app_bar_subtitle_size"
+                android:orientation="vertical"
+                android:paddingHorizontal="@dimen/ss_reading_toolbar_title_margin_left"
                 app:layout_collapseMode="parallax"
-                app:layout_collapseParallaxMultiplier="0.4"
-                tools:text="Tuesday, January 31" />
+                app:layout_collapseParallaxMultiplier="0.4">
+
+                <TextView
+                    android:id="@+id/ss_reading_expanded_title"
+                    style="@style/ReadingExpandedTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/spacing_micro"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    tools:text="How to Get Out of Debt" />
+
+                <TextView
+                    android:id="@+id/ss_collapsing_toolbar_subtitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:fontFamily="@font/lato_bold"
+                    android:maxLines="1"
+                    android:textAllCaps="true"
+                    android:textColor="@color/ss_color_secondary_lighter"
+                    android:textSize="@dimen/ss_reading_app_bar_subtitle_size"
+                    tools:text="Tuesday, January 31" />
+            </LinearLayout>
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/ss_reading_toolbar"

--- a/features/lessons/src/main/res/values/styles.xml
+++ b/features/lessons/src/main/res/values/styles.xml
@@ -32,7 +32,12 @@
         <item name="android:fontFamily">@font/lato_bold</item>
     </style>
 
-    <style name="AppThemeAppBarTextStyleExpanded" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <style name="AppThemeAppBarTextStyleExpanded">
+        <item name="android:textSize">0sp</item>
+        <item name="android:textColor">@android:color/transparent</item>
+    </style>
+
+    <style name="ReadingExpandedTitle" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
         <item name="android:textSize">26sp</item>
         <item name="fontFamily">@font/lato_bold</item>
         <item name="android:fontFamily">@font/lato_bold</item>


### PR DESCRIPTION
# What did you change:

Multi-line CollapsingToolbarLayout doesn’t use the entire screen width in expanded state so fixing this by using a custom view so more content is visible.

# Screenshot/GIFs of this change

| Before                       | After                       |
| ----------------------------- | ----------------------------- |
| ![Before](https://user-images.githubusercontent.com/5994683/223032025-365bd450-898d-4ba3-ab61-757706fb9cd4.png)  | ![After](https://user-images.githubusercontent.com/5994683/223035403-f5b4444d-668e-4d70-bb7e-a2bcfb7838ae.png)



# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests