### PR TITLE
Don't show context menu on highlight click. 

### DIFF
--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingViewModel.kt
@@ -165,7 +165,6 @@ class SSReadingViewModel @AssistedInject constructor(
     }
 
     override fun onSelectionStarted(x: Float, y: Float, highlightId: Int) {
-        onSelectionStarted(x, y)
         this.highlightId = highlightId
     }
 


### PR DESCRIPTION
# What did you change:

This closes #81.

Now we intentionally won't show the context menu when you click a highlight but will only show when you long-press text.
This is similar behaviour to what we have on iOS

# Screenshot/GIFs of this change


https://github.com/Adventech/sabbath-school-android/assets/5994683/a973e519-fb95-4d19-8779-8bafe47530f9



# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests