### PR TITLE
Fix PDF-only quarterlies do not show the "video/audio" playback icons

### DIFF
--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -24,9 +24,7 @@ import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
-    alias(libs.plugins.ksp)
     alias(libs.plugins.sgp.base)
-   // alias(libs.plugins.sgp.apkVersioning)
     id("com.android.application")
     id("dagger.hilt.android.plugin")
     id("kotlin-parcelize")
@@ -114,8 +112,6 @@ dependencies {
     implementation(libs.google.hilt.android)
     kapt(libs.google.hilt.compiler)
     implementation(libs.kotlinx.collectionsImmutable)
-    implementation(libs.square.moshi.kotlin)
-    ksp(libs.square.moshi.codegen)
     implementation(libs.timber)
 
     testImplementation(libs.bundles.testing.common)

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/readings/SSReadingActivity.kt
@@ -38,7 +38,6 @@ import androidx.viewpager2.widget.ViewPager2
 import app.ss.media.playback.PlaybackViewModel
 import app.ss.media.playback.ui.nowPlaying.showNowPlaying
 import app.ss.media.playback.ui.video.showVideoList
-import app.ss.models.media.MediaAvailability
 import app.ss.pdf.PdfReader
 import coil.load
 import com.cryart.sabbathschool.core.extensions.context.isDarkTheme
@@ -222,11 +221,7 @@ class SSReadingActivity : SlidingActivity(), ShareableScreen {
             R.id.ss_reading_menu_pdf -> {
                 val (index, pdfs) = viewModel.lessonPdfsFlow.value
                 if (pdfs.isNotEmpty()) {
-                    val media = MediaAvailability(
-                        audio = viewModel.audioAvailableFlow.value,
-                        video = viewModel.videoAvailableFlow.value
-                    )
-                    startActivity(pdfReader.launchIntent(pdfs, index, mediaAvailability = media))
+                    startActivity(pdfReader.launchIntent(pdfs, index))
                 }
                 true
             }

--- a/features/pdf/build.gradle.kts
+++ b/features/pdf/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Adventech <info@adventech.io>
+ * Copyright (c) 2023. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,7 +13,7 @@
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -71,7 +71,7 @@ dependencies {
     implementation(libs.timber)
 
     implementation(libs.pdfkit) {
-        // We don't need this transitive dependencies
+        // We don't need these transitive dependencies
         exclude(group = "com.google.android.material", module = "material")
         exclude(group = "androidx.compose.runtime", module = "runtime") // imported as aar and breaks the build
     }

--- a/features/pdf/src/main/AndroidManifest.xml
+++ b/features/pdf/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2021. Adventech <info@adventech.io>
+  ~ Copyright (c) 2023. Adventech <info@adventech.io>
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -13,7 +13,7 @@
   ~
   ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
   ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
   ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN

--- a/features/pdf/src/main/kotlin/app/ss/pdf/PdfReader.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/PdfReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Adventech <info@adventech.io>
+ * Copyright (c) 2023. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,6 @@ import android.content.Intent
 import android.net.Uri
 import androidx.annotation.Keep
 import app.ss.models.LessonPdf
-import app.ss.models.media.MediaAvailability
-import app.ss.pdf.ui.ARG_MEDIA_AVAILABILITY
 import app.ss.pdf.ui.ARG_PDF_FILES
 import app.ss.pdf.ui.SSReadPdfActivity
 import com.cryart.sabbathschool.core.response.Resource
@@ -42,6 +40,7 @@ import com.pspdfkit.configuration.sharing.ShareFeatures
 import com.pspdfkit.document.download.DownloadJob
 import com.pspdfkit.document.download.DownloadRequest
 import com.pspdfkit.ui.PdfActivityIntentBuilder
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -51,6 +50,8 @@ import ss.misc.SSConstants
 import timber.log.Timber
 import java.io.File
 import java.util.EnumSet
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -61,14 +62,14 @@ interface PdfReader {
     fun launchIntent(
         pdfs: List<LessonPdf>,
         lessonIndex: String,
-        mediaAvailability: MediaAvailability = MediaAvailability()
     ): Intent
 
     fun downloadFlow(pdfs: List<LessonPdf>): Flow<Resource<List<LocalFile>>>
 }
 
-internal class PdfReaderImpl(
-    private val context: Context,
+@Singleton
+internal class PdfReaderImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val readerPrefs: PdfReaderPrefs,
     private val dispatcherProvider: DispatcherProvider
 ) : PdfReader, DownloadJob.ProgressListenerAdapter() {
@@ -82,7 +83,7 @@ internal class PdfReaderImpl(
         AnnotationType.FREETEXT
     )
 
-    override fun launchIntent(pdfs: List<LessonPdf>, lessonIndex: String, mediaAvailability: MediaAvailability): Intent {
+    override fun launchIntent(pdfs: List<LessonPdf>, lessonIndex: String): Intent {
         val excludedAnnotationTypes = ArrayList(EnumSet.allOf(AnnotationType::class.java))
         allowedAnnotations.forEach { excludedAnnotationTypes.remove(it) }
 
@@ -115,7 +116,6 @@ internal class PdfReaderImpl(
             .apply {
                 putParcelableArrayListExtra(ARG_PDF_FILES, ArrayList(pdfs))
                 putExtra(SSConstants.SS_LESSON_INDEX_EXTRA, lessonIndex)
-                putExtra(ARG_MEDIA_AVAILABILITY, mediaAvailability)
             }
     }
 

--- a/features/pdf/src/main/kotlin/app/ss/pdf/PdfReaderPrefs.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/PdfReaderPrefs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Adventech <info@adventech.io>
+ * Copyright (c) 2023. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,7 +13,7 @@
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -31,6 +31,9 @@ import com.pspdfkit.configuration.page.PageLayoutMode
 import com.pspdfkit.configuration.page.PageScrollDirection
 import com.pspdfkit.configuration.page.PageScrollMode
 import com.pspdfkit.configuration.theming.ThemeMode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
 
 interface PdfReaderPrefs {
     fun scrollMode(): PageScrollMode
@@ -44,10 +47,11 @@ interface PdfReaderPrefs {
     fun saveConfiguration(configuration: PdfConfiguration)
 }
 
-internal class PdfReaderPrefsImpl(
-    private val context: Context,
-    private val sharedPreferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+@Singleton
+internal class PdfReaderPrefsImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
 ) : PdfReaderPrefs {
+    private val sharedPreferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     override fun scrollMode(): PageScrollMode =
         sharedPreferences.getString(KEY_SCROLL_MODE, null)?.let {

--- a/features/pdf/src/main/kotlin/app/ss/pdf/di/BindingsModule.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/di/BindingsModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Adventech <info@adventech.io>
+ * Copyright (c) 2023. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,7 +13,7 @@
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -22,38 +22,22 @@
 
 package app.ss.pdf.di
 
-import android.content.Context
 import app.ss.pdf.PdfReader
 import app.ss.pdf.PdfReaderImpl
 import app.ss.pdf.PdfReaderPrefs
 import app.ss.pdf.PdfReaderPrefsImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import ss.foundation.coroutines.DispatcherProvider
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object PdfModule {
+abstract class BindingsModule {
 
-    @Provides
-    @Singleton
-    fun provideReaderPrefs(
-        @ApplicationContext context: Context
-    ): PdfReaderPrefs = PdfReaderPrefsImpl(context)
+    @Binds
+    internal abstract fun bindReaderPrefs(impl: PdfReaderPrefsImpl): PdfReaderPrefs
 
-    @Provides
-    @Singleton
-    fun provideReader(
-        @ApplicationContext context: Context,
-        readerPrefs: PdfReaderPrefs,
-        dispatcherProvider: DispatcherProvider
-    ): PdfReader = PdfReaderImpl(
-        context = context,
-        readerPrefs = readerPrefs,
-        dispatcherProvider = dispatcherProvider
-    )
+    @Binds
+    internal abstract fun bindReader(impl: PdfReaderImpl): PdfReader
 }

--- a/features/pdf/src/main/kotlin/app/ss/pdf/ui/SSReadPdfActivity.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/ui/SSReadPdfActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. Adventech <info@adventech.io>
+ * Copyright (c) 2023. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,7 +13,7 @@
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -68,7 +68,7 @@ class SSReadPdfActivity : PdfActivity() {
 
     override fun onGenerateMenuItemIds(menuItems: MutableList<Int>): MutableList<Int> {
         return menuItems.also {
-            val media = viewModel.mediaActivity
+            val media = viewModel.mediaAvailabilityFlow.value
             if (media.video) {
                 it.add(0, ID_VIDEO)
             }
@@ -141,6 +141,8 @@ class SSReadPdfActivity : PdfActivity() {
 
             loadAnnotations(document, annotations)
         }
+
+        viewModel.mediaAvailabilityFlow.collectIn(this) { invalidateOptionsMenu() }
     }
 
     override fun onDocumentLoaded(document: PdfDocument) {
@@ -180,4 +182,3 @@ class SSReadPdfActivity : PdfActivity() {
 }
 
 internal const val ARG_PDF_FILES = "ss_arg_pdf_files"
-internal const val ARG_MEDIA_AVAILABILITY = "ss_arg_media_availability"


### PR DESCRIPTION
# What did you change:

Fixes the bug PDF-only quarterlies do not show the "video/audio" playback icons

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests