### PR TITLE
Download quarter improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,7 +219,7 @@ object BuildAndroidConfig {
 
     object Version {
         private const val MAJOR = 4
-        private const val MINOR = 44
+        private const val MINOR = 45
         private const val PATCH = 0
 
         const val name = "$MAJOR.$MINOR.$PATCH"

--- a/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/components/QuarterlyInfo.kt
+++ b/features/lessons/src/main/java/com/cryart/sabbathschool/lessons/ui/lessons/components/QuarterlyInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -434,7 +434,7 @@ private fun ColumnScope.ReadButton(
                 OfflineState.PARTIAL,
                 OfflineState.NONE -> ResIcon.Download
 
-                OfflineState.IN_PROGRESS -> ResIcon.Downloading
+                OfflineState.IN_PROGRESS -> null
                 OfflineState.COMPLETE -> ResIcon.Downloaded
             }
         )
@@ -494,7 +494,7 @@ private fun ColumnScope.ReadButton(
                         color = downloadButtonIconColor
                     )
 
-                    IconBox(icon = targetIcon)
+                    targetIcon?.let { IconBox(icon = it) }
                 }
             }
         }

--- a/features/settings/src/main/kotlin/ss/settings/repository/SettingsRepository.kt
+++ b/features/settings/src/main/kotlin/ss/settings/repository/SettingsRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -174,6 +174,13 @@ internal class SettingsRepositoryImpl @Inject constructor(
             id = "section-account"
         ),
         PrefListEntity.Generic(
+            id = "downloads-delete",
+            enabled = hasDownloads,
+            title = ContentSpec.Res(L10nR.string.ss_delete_downloads),
+            onClick = { onEntityClick(SettingsEntity.Account.DeleteContent) },
+            withWarning = true
+        ),
+        PrefListEntity.Generic(
             title = ContentSpec.Res(L10nR.string.ss_menu_sign_out),
             id = "account-sign-out",
             onClick = { onEntityClick(SettingsEntity.Account.SignOut) },
@@ -183,16 +190,6 @@ internal class SettingsRepositoryImpl @Inject constructor(
             title = ContentSpec.Res(L10nR.string.ss_delete_account),
             id = "account-delete",
             onClick = { onEntityClick(SettingsEntity.Account.Delete) },
-            withWarning = true
-        ),
-
-        DividerEntity(id = "divider-three"),
-
-        PrefListEntity.Generic(
-            id = "downloads-delete",
-            enabled = hasDownloads,
-            title = ContentSpec.Res(L10nR.string.ss_delete_downloads),
-            onClick = { onEntityClick(SettingsEntity.Account.DeleteContent) },
             withWarning = true
         ),
     )

--- a/libraries/storage/test/src/main/kotlin/app/ss/storage/test/FakeQuarterliesDao.kt
+++ b/libraries/storage/test/src/main/kotlin/app/ss/storage/test/FakeQuarterliesDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,8 @@ class FakeQuarterliesDao : QuarterliesDao {
     private val languageEntityMap: MutableMap<String, List<QuarterlyEntity>> = mutableMapOf()
     var infoEntitiesForSync: List<QuarterlyInfoEntity> = emptyList()
 
+    var quarterlyCovers: List<String> = emptyList()
+
     var lastUpdatedQuarterly: QuarterlyEntity? = null
         private set
 
@@ -71,9 +73,7 @@ class FakeQuarterliesDao : QuarterliesDao {
         TODO("Not yet implemented")
     }
 
-    override suspend fun getCovers(language: String): List<String> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCovers(language: String): List<String> = quarterlyCovers
 
     override suspend fun getOfflineState(index: String): OfflineState? {
         TODO("Not yet implemented")

--- a/libraries/workers/api/build.gradle.kts
+++ b/libraries/workers/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,4 +23,8 @@
 plugins {
     alias(libs.plugins.sgp.base)
     kotlin("jvm")
+}
+
+dependencies {
+    implementation(libs.androidx.annotations)
 }

--- a/libraries/workers/api/src/main/kotlin/ss/workers/api/WorkScheduler.kt
+++ b/libraries/workers/api/src/main/kotlin/ss/workers/api/WorkScheduler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,13 @@ interface WorkScheduler {
      * @param language The current selected language.
      */
     fun preFetchImages(language: String)
+
+    /**
+     * Prefetch cover images.
+     *
+     * @param images The images to cache.
+     */
+    fun preFetchImages(images: Set<String>)
 
     /**
      * Schedules background work to download quarterly content matching the given [index].

--- a/libraries/workers/api/src/main/kotlin/ss/workers/api/test/FakeWorkScheduler.kt
+++ b/libraries/workers/api/src/main/kotlin/ss/workers/api/test/FakeWorkScheduler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,27 +20,32 @@
  * THE SOFTWARE.
  */
 
-package ss.workers.impl.workers
+package ss.workers.api.test
 
-import app.ss.models.QuarterlyGroup
-import app.ss.storage.db.entity.QuarterlyInfoEntity
-import ss.libraries.storage.api.dao.QuarterliesDao
-import ss.libraries.storage.api.entity.QuarterlyEntity
+import androidx.annotation.VisibleForTesting
+import ss.workers.api.WorkScheduler
 
-/** Fake implementation of [QuarterliesDao] for use in tests. */
-class FakeQuarterliesDao(private val covers: List<String> = emptyList()): QuarterliesDao {
+@VisibleForTesting
+class FakeWorkScheduler : WorkScheduler {
 
-    override fun get(language: String): List<QuarterlyEntity> = emptyList()
+    var preFetchImagesLanguage: String? = null
+        private set
+    var preFetchImagesImages: Set<String>? = null
+        private set
 
-    override fun get(language: String, group: QuarterlyGroup): List<QuarterlyEntity> = emptyList()
+    override fun preFetchImages(language: String) {
+        this.preFetchImagesLanguage = language
+    }
 
-    override fun getInfo(quarterlyIndex: String): QuarterlyInfoEntity? = null
+    override fun preFetchImages(images: Set<String>) {
+        this.preFetchImagesImages = images
+    }
 
-    override suspend fun getCovers(language: String): List<String> = covers
+    override fun syncQuarterly(index: String) {
+        // no-op
+    }
 
-    override suspend fun insertItem(item: QuarterlyEntity) {}
-
-    override suspend fun insertAll(items: List<QuarterlyEntity>) {}
-
-    override suspend fun update(item: QuarterlyEntity) {}
+    override fun syncQuarterlies() {
+        // no-op
+    }
 }

--- a/services/lessons/impl/build.gradle.kts
+++ b/services/lessons/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ dependencies {
     implementation(projects.common.prefs.api)
     implementation(projects.libraries.foundation.android)
     implementation(projects.libraries.storage.api)
+    implementation(projects.libraries.workers.api)
 
     implementation(libs.google.hilt.android)
     ksp(libs.google.hilt.compiler)

--- a/services/lessons/impl/src/test/kotlin/ss/lessons/impl/ContentSyncProviderImplTest.kt
+++ b/services/lessons/impl/src/test/kotlin/ss/lessons/impl/ContentSyncProviderImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.ss.models.LessonPdf
 import app.ss.models.OfflineState
 import app.ss.models.SSDay
-import app.ss.storage.db.entity.QuarterlyInfoEntity
 import app.ss.storage.test.FakeLessonsDao
 import app.ss.storage.test.FakeQuarterliesDao
 import app.ss.storage.test.FakeReadsDao
@@ -40,7 +39,9 @@ import ss.lessons.test.FakeLessonsApi
 import ss.lessons.test.FakePdfReader
 import ss.libraries.storage.api.entity.LessonEntity
 import ss.libraries.storage.api.entity.QuarterlyEntity
+import ss.libraries.storage.api.entity.QuarterlyInfoEntity
 import ss.libraries.storage.api.entity.ReadEntity
+import ss.workers.api.test.FakeWorkScheduler
 
 @RunWith(AndroidJUnit4::class)
 class ContentSyncProviderImplTest {
@@ -49,6 +50,7 @@ class ContentSyncProviderImplTest {
     private val fakeReadsDao = FakeReadsDao()
     private val fakeLessonsDao = FakeLessonsDao()
     private val fakePdfReader = FakePdfReader()
+    private val fakeWorkScheduler = FakeWorkScheduler()
 
     private val underTest = ContentSyncProviderImpl(
         quarterliesDao = fakeQuarterliesDao,
@@ -57,7 +59,8 @@ class ContentSyncProviderImplTest {
         pdfReader = fakePdfReader,
         lessonsApi = FakeLessonsApi(),
         syncHelper = FakeSyncHelper(),
-        dispatcherProvider = TestDispatcherProvider()
+        workScheduler = fakeWorkScheduler,
+        dispatcherProvider = TestDispatcherProvider(),
     )
 
     private val quarterlyEntity = QuarterlyEntity(
@@ -88,7 +91,7 @@ class ContentSyncProviderImplTest {
         title = "Title",
         start_date = "date",
         end_date = "date",
-        cover = "",
+        cover = "cover",
         id = "id",
         path = "path",
         full_path = "",

--- a/services/workers/impl/build.gradle.kts
+++ b/services/workers/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,4 +57,5 @@ dependencies {
     testImplementation(libs.test.androidx.work)
     testImplementation(projects.libraries.foundation.coroutines.test)
     testImplementation(projects.libraries.lessons.test)
+    testImplementation(projects.libraries.storage.test)
 }

--- a/services/workers/impl/src/test/kotlin/ss/workers/impl/FakeWorkManager.kt
+++ b/services/workers/impl/src/test/kotlin/ss/workers/impl/FakeWorkManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkQuery
 import androidx.work.WorkRequest
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 /** Fake implementation of [WorkManager] for use in tests. */
@@ -128,11 +129,19 @@ class FakeWorkManager : WorkManager() {
         TODO("Not yet implemented")
     }
 
+    override fun getWorkInfoByIdFlow(id: UUID): Flow<WorkInfo> {
+        TODO("Not yet implemented")
+    }
+
     override fun getWorkInfoById(id: UUID): ListenableFuture<WorkInfo> {
         TODO("Not yet implemented")
     }
 
     override fun getWorkInfosByTagLiveData(tag: String): LiveData<MutableList<WorkInfo>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getWorkInfosByTagFlow(tag: String): Flow<MutableList<WorkInfo>> {
         TODO("Not yet implemented")
     }
 
@@ -144,11 +153,19 @@ class FakeWorkManager : WorkManager() {
         TODO("Not yet implemented")
     }
 
+    override fun getWorkInfosForUniqueWorkFlow(uniqueWorkName: String): Flow<MutableList<WorkInfo>> {
+        TODO("Not yet implemented")
+    }
+
     override fun getWorkInfosForUniqueWork(uniqueWorkName: String): ListenableFuture<MutableList<WorkInfo>> {
         TODO("Not yet implemented")
     }
 
     override fun getWorkInfosLiveData(workQuery: WorkQuery): LiveData<MutableList<WorkInfo>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getWorkInfosFlow(workQuery: WorkQuery): Flow<MutableList<WorkInfo>> {
         TODO("Not yet implemented")
     }
 

--- a/services/workers/impl/src/test/kotlin/ss/workers/impl/workers/PrefetchImagesWorkerTest.kt
+++ b/services/workers/impl/src/test/kotlin/ss/workers/impl/workers/PrefetchImagesWorkerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,10 +51,23 @@ class PrefetchImagesWorkerTest {
     }
 
     @Test
-    fun `doWork - returns success when done caching images`() = runTest {
+    fun `doWork - returns success when done caching quarterly language`() = runTest {
         val worker = TestListenableWorkerBuilder<PrefetchImagesWorker>(
             context = appContext,
             inputData = workDataOf(PrefetchImagesWorker.LANGUAGE_KEY to "en")
+        ).setWorkerFactory(TestWorkerFactory())
+            .build()
+
+        val result = worker.doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.success()
+    }
+
+    @Test
+    fun `doWork - returns success when done caching images`() = runTest {
+        val worker = TestListenableWorkerBuilder<PrefetchImagesWorker>(
+            context = appContext,
+            inputData = workDataOf(PrefetchImagesWorker.IMAGES_KEY to arrayOf("image1", "image2"))
         ).setWorkerFactory(TestWorkerFactory())
             .build()
 

--- a/services/workers/impl/src/test/kotlin/ss/workers/impl/workers/TestWorkerFactory.kt
+++ b/services/workers/impl/src/test/kotlin/ss/workers/impl/workers/TestWorkerFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2024. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
+import app.ss.storage.test.FakeQuarterliesDao
 import ss.foundation.coroutines.test.TestDispatcherProvider
 import ss.lessons.api.ContentSyncProvider
 import ss.lessons.test.FakeContentSyncProvider


### PR DESCRIPTION
# What did you change:

- Update downloading icon. Remove the cloud icon and leave the spinning circle only
- Download lesson cover images for each lesson
- Move "Remove all downloads" to be the first in the list (before Sign Out)

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [x] Automated (unit/ui) tests
- [x] Manual tests