### PR TITLE
Fix: Czech strings ss_about_made

### DIFF
--- a/common/translations/src/main/res/values-cs/strings.xml
+++ b/common/translations/src/main/res/values-cs/strings.xml
@@ -60,7 +60,7 @@
     <string name="ss_reading_copied">"Výběr byl zkopírován."</string>
     <string name="ss_reading_share_to">"Sdílet výběr:"</string>
 
-    <string name="ss_about_made">"Vyrobeno z ❤ od Adventech"</string>
+    <string name="ss_about_made">"Vyrobil s ❤ Adventech"</string>
     <string name="ss_settings_display_options">"Možnosti zobrazení"</string>
     <string name="ss_settings_color_theme_light">"Světlý"</string>
     <string name="ss_settings_color_theme_sepia">"Sépie"</string>


### PR DESCRIPTION
# Simple language fix

Made a simple language fix.

Direct translation of "Made with ❤ by Adventech" is "Vyrobeno s ❤ od Adventech" instead of "Vyrobeno z ❤ od Adventech". However I changed it into "Vyrobil s ❤ Adventech" this way it sounds better, short for "Vyrobil s láskou Adventech".

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [ ] Automated (unit/ui) tests
- [ ] Manual tests