### PR TITLE
Remove deprecated gradle cache step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '21'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,15 +37,11 @@ jobs:
 #            ~/.android/adb*
 #          key: avd-${{ matrix.api-level }}
 
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Execute Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,23 +36,27 @@ jobs:
 #            ~/.android/avd/*
 #            ~/.android/adb*
 #          key: avd-${{ matrix.api-level }}
+#
+#      - name: create AVD and generate snapshot for caching
+#        if: steps.avd-cache.outputs.cache-hit != 'true'
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ matrix.api-level }}
+#          force-avd-creation: false
+#          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#          disable-animations: false
+#          script: echo "Generated AVD snapshot for caching."
+#
+#      - name: Execute Instrumentation Tests
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{matrix.api-level}}
+#          target: ${{matrix.target}}
+#          arch: x86_64
+#          force-avd-creation: true
+#          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#          disable-animations: true
+#          script: ./gradlew app:connectedCheck --stacktrace
 
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Execute Instrumentation Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{matrix.api-level}}
-          target: ${{matrix.target}}
-          arch: x86_64
-          force-avd-creation: true
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew app:connectedCheck --stacktrace
-
-     # - name: Build Release
-     #   run: ./gradlew app:bundleRelease --stacktrace
+      - name: Build Release
+        run: ./gradlew app:bundleRelease --stacktrace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [34]
         target: [google_apis]
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
 
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+#      - name: AVD cache
+#        uses: actions/cache@v4
+#        id: avd-cache
+#        with:
+#          path: |
+#            ~/.android/avd/*
+#            ~/.android/adb*
+#          key: avd-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,7 @@ android {
 
 slack {
     features { compose() }
+    android { features { androidTest() } }
 }
 
 dependencies {

--- a/app/src/androidTest/java/app/ss/bible/BibleVersesActivityTest.kt
+++ b/app/src/androidTest/java/app/ss/bible/BibleVersesActivityTest.kt
@@ -3,7 +3,6 @@ package app.ss.bible
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.cryart.sabbathschool.test.di.mock.MockDataFactory
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
@@ -20,8 +19,6 @@ class BibleVersesActivityTest {
     var hiltRule = HiltAndroidRule(this)
 
     private var scenario: ActivityScenario<BibleVersesActivity>? = null
-
-    private val versions = MockDataFactory.versions
 
     @Before
     fun setup() {

--- a/app/src/androidTest/java/com/cryart/sabbathschool/quarterlies/QuarterliesActivityTest.kt
+++ b/app/src/androidTest/java/com/cryart/sabbathschool/quarterlies/QuarterliesActivityTest.kt
@@ -26,7 +26,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.cryart.sabbathschool.core.extensions.prefs.SSPrefs
 import com.cryart.sabbathschool.lessons.ui.quarterlies.QuarterliesActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -35,6 +34,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import ss.prefs.api.SSPrefs
 import javax.inject.Inject
 
 @HiltAndroidTest

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,9 +47,10 @@ kotlin.code.style=official
 org.gradle.vfs.watch=true
 
 slack.robolectricTestSdks=28,29,30,31,32,33,34
-slack.robolectricIVersion=4
+slack.robolectricIVersion=6
 slack.compileSdkVersion=android-34
 slack.minSdkVersion=24
 slack.targetSdkVersion=34
 slack.auto-apply.detekt=false
 slack.lint.baseline-file-name=lint-baseline.xml
+slack.location.robolectric-core=:libraries:test_utils:robolectric-core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ markwon = "4.6.2"
 material-dialogs = "3.3.0"
 # @keep this version
 pdfkit = "2024.2.1"
+robolectric = "4.12.1"
 sgp = "0.16.3"
 snapper = "0.3.0"
 sortDependencies = "0.6"
@@ -68,7 +69,6 @@ test-androidx-uiautomator = "2.3.0"
 test-junit = "4.13.2"
 test-kluent = "1.73"
 test-mockk = "1.13.10"
-test-robolectric = "4.12.1"
 timber = "5.0.1"
 
 [libraries]
@@ -183,7 +183,7 @@ test-google-hilt = { module = "com.google.dagger:hilt-android-testing", version.
 test-junit = { module = "junit:junit", version.ref = "test-junit" }
 test-kluent = { module = "org.amshove.kluent:kluent-android", version.ref = "test-kluent" }
 test-mockk = { module = "io.mockk:mockk", version.ref = "test-mockk" }
-test-robolectric = { module = "org.robolectric:robolectric", version.ref = "test-robolectric" }
+test-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "cash-app-turbine" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 

--- a/libraries/test_utils/robolectric-core/build.gradle.kts
+++ b/libraries/test_utils/robolectric-core/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.sgp.base)
+}

--- a/libraries/test_utils/robolectric-core/gradle.properties
+++ b/libraries/test_utils/robolectric-core/gradle.properties
@@ -1,0 +1,1 @@
+sgp.isTestLibrary=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -78,6 +78,7 @@ include(
     ":libraries:storage:api",
     ":libraries:storage:test",
     ":libraries:test_utils",
+    ":libraries:test_utils:robolectric-core",
     ":libraries:ui:placeholder",
     ":libraries:workers:api",
     ":services:circuit:impl",


### PR DESCRIPTION
# What did you change:

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

# Screenshot/GIFs of this change

_Quick glance of what is changing where_

# Merge checklist

- [ ] Automated (unit/ui) tests
- [ ] Manual tests