### PR TITLE
Disable list parsing in HeadingContent

### DIFF
--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
@@ -49,5 +49,6 @@ internal fun HeadingContent(
         textAlign = Styler.textAlign(blockStyle),
         onHandleUri = onHandleUri,
         highlights = highlights,
+        disableListParser = true,
     )
 }


### PR DESCRIPTION
# What did you change:

As I could see, in the HeadingContent there is no need to parse markdown lists. In case of HeadingContent only the parsing of lists is disabled.

## Reason for the change:

Verse headlines were not shown for verses of type: "2. Коринтјани 4,4" (starting with number and a dot).

# Screenshot/GIFs of this change

**Before:**
![Screenshot 2025-03-07 at 15 24 18](https://github.com/user-attachments/assets/0af760b3-cf90-41df-b130-a24e477f2d91)

**After:**
![Screenshot 2025-03-07 at 15 22 18](https://github.com/user-attachments/assets/a2e7ae50-65e9-4fea-b694-10289c19e9a7)

As you can see there was a missing heading in case of a heading of the format "number." because it is considered as a list in markdown.

# Merge checklist

- [ ] Automated (unit/ui) tests
- [ ] Manual tests