### PR TITLE
Add support for parsing markdown ListBlocks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -220,7 +220,7 @@ object BuildAndroidConfig {
     object Version {
         private const val MAJOR = 5
         private const val MINOR = 3
-        private const val PATCH = 0
+        private const val PATCH = 1
 
         const val name = "$MAJOR.$MINOR.$PATCH"
     }

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
@@ -22,14 +22,21 @@
 
 package io.adventech.blockkit.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import io.adventech.blockkit.model.BlockItem
 import io.adventech.blockkit.ui.input.UserInputState
 import io.adventech.blockkit.ui.input.rememberContentHighlights
 import io.adventech.blockkit.ui.style.HeadingStyleTemplate
 import io.adventech.blockkit.ui.style.Styler
+import io.adventech.blockkit.ui.style.theme.BlocksPreviewTheme
 
 @Composable
 internal fun HeadingContent(
@@ -50,4 +57,39 @@ internal fun HeadingContent(
         onHandleUri = onHandleUri,
         highlights = highlights,
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun Preview() {
+    BlocksPreviewTheme {
+        Surface {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                HeadingContent(
+                    blockItem = BlockItem.Heading(
+                        id = "heading",
+                        style = null,
+                        data = null,
+                        nested = null,
+                        markdown = "Heading",
+                        depth = 1,
+                    ),
+                )
+
+                HeadingContent(
+                    blockItem = BlockItem.Heading(
+                        id = "heading-two",
+                        style = null,
+                        data = null,
+                        nested = null,
+                        markdown = "2. Heading",
+                        depth = 1,
+                    ),
+                )
+            }
+        }
+    }
 }

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/HeadingContent.kt
@@ -89,6 +89,17 @@ private fun Preview() {
                         depth = 1,
                     ),
                 )
+
+                HeadingContent(
+                    blockItem = BlockItem.Heading(
+                        id = "heading-three",
+                        style = null,
+                        data = null,
+                        nested = null,
+                        markdown = "- Heading",
+                        depth = 1,
+                    ),
+                )
             }
         }
     }

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
@@ -75,6 +75,7 @@ import me.saket.extendedspans.ExtendedSpans
 import me.saket.extendedspans.RoundedCornerSpanPainter
 import me.saket.extendedspans.RoundedCornerSpanPainter.TextPaddingValues
 import me.saket.extendedspans.drawBehind
+import org.commonmark.node.BulletList
 import org.commonmark.node.Code
 import org.commonmark.node.Document
 import org.commonmark.node.Emphasis
@@ -85,6 +86,7 @@ import org.commonmark.node.Link
 import org.commonmark.node.ListBlock
 import org.commonmark.node.ListItem
 import org.commonmark.node.Node
+import org.commonmark.node.OrderedList
 import org.commonmark.node.Paragraph
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
@@ -281,6 +283,17 @@ internal fun AnnotatedString.Builder.appendMarkdownChildren(
                 appendMarkdownChildren(child, color, fontSize, parser, fontProvider, fontSizeProvider)
             }
             is ListBlock -> {
+                when (child) {
+                    is OrderedList -> {
+                        append(child.startNumber.toString())
+                        append(child.delimiter)
+                        append(" ")
+                    }
+                    is BulletList -> {
+                        append(child.bulletMarker)
+                        append("")
+                    }
+                }
                 appendMarkdownChildren(child.firstChild, color, fontSize, parser, fontProvider, fontSizeProvider)
             }
         }

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
@@ -291,7 +291,7 @@ internal fun AnnotatedString.Builder.appendMarkdownChildren(
                     }
                     is BulletList -> {
                         append(child.bulletMarker)
-                        append("")
+                        append(" ")
                     }
                 }
                 appendMarkdownChildren(child.firstChild, color, fontSize, parser, fontProvider, fontSizeProvider)

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
@@ -82,6 +82,8 @@ import org.commonmark.node.HardLineBreak
 import org.commonmark.node.Heading
 import org.commonmark.node.Image
 import org.commonmark.node.Link
+import org.commonmark.node.ListBlock
+import org.commonmark.node.ListItem
 import org.commonmark.node.Node
 import org.commonmark.node.Paragraph
 import org.commonmark.node.StrongEmphasis
@@ -273,6 +275,13 @@ internal fun AnnotatedString.Builder.appendMarkdownChildren(
                     appendMarkdownChildren(child, color, fontSize, parser, fontProvider, fontSizeProvider)
                 }
                 appendLine()
+            }
+
+            is ListItem -> {
+                appendMarkdownChildren(child, color, fontSize, parser, fontProvider, fontSizeProvider)
+            }
+            is ListBlock -> {
+                appendMarkdownChildren(child.firstChild, color, fontSize, parser, fontProvider, fontSizeProvider)
             }
         }
         child = child.next


### PR DESCRIPTION
# What did you change:

Add parsing ListBlock and ListItem as verse headings in some languages come in as List items.

# Screenshot/GIFs of this change

https://github.com/user-attachments/assets/08c5af37-d80b-44ff-8b9c-5093c729e773

# Merge checklist

- [ ] Automated (unit/ui) tests
- [ ] Manual tests