### PR TITLE
fix(android): remove keepScreenOn to prevent burn-in

### DIFF
--- a/features/document/src/main/kotlin/ss/document/DocumentScreenUi.kt
+++ b/features/document/src/main/kotlin/ss/document/DocumentScreenUi.kt
@@ -115,7 +115,6 @@ fun DocumentScreenUi(state: State, modifier: Modifier = Modifier) {
     HazeScaffold(
         modifier = modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)
-            .keepScreenOn(),
         topBar = {
             AnimatedVisibility(
                 visible = state.showTopBar(collapsed),


### PR DESCRIPTION
Removes Modifier.keepScreenOn() from DocumentScreenUi to let the device respect normal screen timeout and avoid burn‑in risk (issue #1463).