### PR TITLE
fix(block-kit): serialize paragraph mark mutations

### DIFF
--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/ParagraphContent.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/ParagraphContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +50,6 @@ import io.adventech.blockkit.model.input.Highlight
 import io.adventech.blockkit.model.input.HighlightColor
 import io.adventech.blockkit.model.input.Underline
 import io.adventech.blockkit.model.input.UserInput
-import io.adventech.blockkit.model.input.UserInputRequest
 import io.adventech.blockkit.ui.input.MarkdownTextInput
 import io.adventech.blockkit.ui.input.SelectionBlockContainer
 import io.adventech.blockkit.ui.input.UserInputState
@@ -123,16 +123,29 @@ private fun SelectableParagraph(
 
     val highlights = rememberContentHighlights(blockItem.id, inputState)
     val underlines = rememberContentUnderlines(blockItem.id, inputState)
-    var localHighlights by remember(highlights) { mutableStateOf(highlights) }
-    var localUnderlines by remember(underlines) { mutableStateOf(underlines) }
+    val persistedHighlights: UserInput.Highlights? = inputState?.find(blockItem.id)
+    val persistedUnderlines: UserInput.Underlines? = inputState?.find(blockItem.id)
+    val inputReducer = remember(blockItem.id) {
+        ParagraphUserInputReducer(
+            blockId = blockItem.id,
+            initialHighlights = highlights,
+            initialUnderlines = underlines,
+        )
+    }
+    LaunchedEffect(persistedHighlights) {
+        inputReducer.acceptPersistedHighlights(highlights)
+    }
+    LaunchedEffect(persistedUnderlines) {
+        inputReducer.acceptPersistedUnderlines(underlines)
+    }
 
     val styledText = rememberMarkdownText(
         markdownText = blockItem.markdown,
         style = Styler.textStyle(blockStyle),
         styleTemplate = BlockStyleTemplate.DEFAULT,
         color = Styler.textColor(blockStyle),
-        highlights = localHighlights,
-        underlines = localUnderlines,
+        highlights = inputReducer.highlights,
+        underlines = inputReducer.underlines,
     )
 
     val extendedSpans = remember {
@@ -163,26 +176,13 @@ private fun SelectableParagraph(
         selection = currentSelection,
         modifier = modifier,
         onHighlight = { highlight ->
-            val input: UserInput.Highlights? = inputState?.find(blockItem.id)
-            val highlights = input?.highlights.orEmpty() + highlight
-            val request = UserInputRequest.Highlights(
-                blockId = blockItem.id,
-                highlights = highlights,
-            )
-            localHighlights = highlights.toImmutableList()
+            val request = inputReducer.addHighlight(highlight)
             inputState?.eventSink?.invoke(UserInputState.Event.InputChanged(request))
             clearSelection()
         },
         onRemoveHighlight = {
             // Remove any highlight who's startIndex and endIndex are in the range of the current selection
-            val selection = currentSelection
-            val input: UserInput.Highlights? = inputState?.find(blockItem.id)
-            val highlights = removeHighlightsInRange(input?.highlights.orEmpty(), selection)
-            val request = UserInputRequest.Highlights(
-                blockId = blockItem.id,
-                highlights = highlights
-            )
-            localHighlights = highlights.toImmutableList()
+            val request = inputReducer.removeHighlights(currentSelection)
             inputState?.eventSink?.invoke(UserInputState.Event.InputChanged(request))
             clearSelection()
         },
@@ -199,43 +199,13 @@ private fun SelectableParagraph(
             clearSelection()
         },
         onUnderLine = { underline ->
-            val selection = currentSelection
-            val input: UserInput.Underlines? = inputState?.find(blockItem.id)
-            val existingUnderlines = input?.underlines.orEmpty()
-
-            if (underlinesInRange(existingUnderlines, selection).isNotEmpty()) {
-                // If there are existing underlines in the selection range, remove them
-                val updatedUnderlines = removeUnderlinesInRange(existingUnderlines, selection)
-                localUnderlines = updatedUnderlines.toImmutableList()
-                inputState?.eventSink?.invoke(
-                    UserInputState.Event.InputChanged(
-                        UserInputRequest.Underlines(
-                            blockId = blockItem.id,
-                            underlines = updatedUnderlines
-                        )
-                    )
-                )
-            } else {
-                val underlines = existingUnderlines + underline
-                val request = UserInputRequest.Underlines(
-                    blockId = blockItem.id,
-                    underlines = underlines
-                )
-                localUnderlines = underlines.toImmutableList()
-                inputState?.eventSink?.invoke(UserInputState.Event.InputChanged(request))
-            }
+            val request = inputReducer.toggleUnderline(underline, currentSelection)
+            inputState?.eventSink?.invoke(UserInputState.Event.InputChanged(request))
             clearSelection()
         },
         onRemoveUnderline = {
             // Remove any underline who's startIndex and endIndex are in the range of the current selection
-            val selection = currentSelection
-            val input: UserInput.Underlines? = inputState?.find(blockItem.id)
-            val underlines = removeUnderlinesInRange(input?.underlines.orEmpty(), selection)
-            val request = UserInputRequest.Underlines(
-                blockId = blockItem.id,
-                underlines = underlines
-            )
-            localUnderlines = underlines.toImmutableList()
+            val request = inputReducer.removeUnderlines(currentSelection)
             inputState?.eventSink?.invoke(UserInputState.Event.InputChanged(request))
             clearSelection()
         }
@@ -249,33 +219,6 @@ private fun SelectableParagraph(
             textAlign = Styler.textAlign(blockStyle),
             onHandleUri = onHandleUri,
         )
-    }
-}
-
-private fun removeHighlightsInRange(highlights: List<Highlight>, range: TextRange): List<Highlight> {
-    return highlights.filterNot { highlight ->
-        highlight.startIndex in range.min..range.max && highlight.endIndex in range.min..range.max ||
-            highlight.startIndex <= range.max && highlight.endIndex >= range.min
-    }
-}
-
-private fun removeUnderlinesInRange(
-    underlines: List<Underline>,
-    range: TextRange
-): List<Underline> {
-    return underlines.filterNot { underline ->
-        underline.startIndex in range.min..range.max && underline.endIndex in range.min..range.max ||
-            underline.startIndex <= range.max && underline.endIndex >= range.min
-    }
-}
-
-private fun underlinesInRange(
-    underlines: List<Underline>,
-    range: TextRange
-): List<Underline> {
-    return underlines.filter { underline ->
-        underline.startIndex in range.min..range.max && underline.endIndex in range.min..range.max ||
-            underline.startIndex <= range.max && underline.endIndex >= range.min
     }
 }
 

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/ParagraphUserInputReducer.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/ParagraphUserInputReducer.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.adventech.blockkit.ui
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.TextRange
+import io.adventech.blockkit.model.input.Highlight
+import io.adventech.blockkit.model.input.Underline
+import io.adventech.blockkit.model.input.UserInputRequest
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * Reduces paragraph mark mutations against the latest optimistic UI state, independently for each
+ * composed block. A lagging persisted emission cannot replace a newer local snapshot; the latest
+ * matching emission acknowledges it.
+ *
+ * This reducer does not provide durable retry or cross-device conflict resolution. Those remain
+ * repository responsibilities.
+ */
+@Stable
+internal class ParagraphUserInputReducer(
+    private val blockId: String,
+    initialHighlights: List<Highlight>,
+    initialUnderlines: List<Underline>,
+) {
+    private var pendingHighlights: ImmutableList<Highlight>? = null
+    private var pendingUnderlines: ImmutableList<Underline>? = null
+
+    var highlights: ImmutableList<Highlight> by mutableStateOf(initialHighlights.toImmutableList())
+        private set
+
+    var underlines: ImmutableList<Underline> by mutableStateOf(initialUnderlines.toImmutableList())
+        private set
+
+    fun acceptPersistedHighlights(highlights: List<Highlight>) {
+        val persistedHighlights = highlights.toImmutableList()
+        if (pendingHighlights == null || pendingHighlights == persistedHighlights) {
+            this.highlights = persistedHighlights
+            pendingHighlights = null
+        }
+    }
+
+    fun acceptPersistedUnderlines(underlines: List<Underline>) {
+        val persistedUnderlines = underlines.toImmutableList()
+        if (pendingUnderlines == null || pendingUnderlines == persistedUnderlines) {
+            this.underlines = persistedUnderlines
+            pendingUnderlines = null
+        }
+    }
+
+    fun addHighlight(highlight: Highlight): UserInputRequest.Highlights {
+        return updateHighlights(highlights + highlight)
+    }
+
+    fun removeHighlights(selection: TextRange): UserInputRequest.Highlights {
+        return updateHighlights(highlights.withoutHighlightsIn(selection))
+    }
+
+    fun toggleUnderline(
+        underline: Underline,
+        selection: TextRange,
+    ): UserInputRequest.Underlines {
+        val updated = if (underlines.underlinesIn(selection).isNotEmpty()) {
+            underlines.withoutUnderlinesIn(selection)
+        } else {
+            underlines + underline
+        }
+        return updateUnderlines(updated)
+    }
+
+    fun removeUnderlines(selection: TextRange): UserInputRequest.Underlines {
+        return updateUnderlines(underlines.withoutUnderlinesIn(selection))
+    }
+
+    private fun updateHighlights(updated: List<Highlight>): UserInputRequest.Highlights {
+        val local = updated.toImmutableList()
+        highlights = local
+        pendingHighlights = local
+        return UserInputRequest.Highlights(blockId = blockId, highlights = local)
+    }
+
+    private fun updateUnderlines(updated: List<Underline>): UserInputRequest.Underlines {
+        val local = updated.toImmutableList()
+        underlines = local
+        pendingUnderlines = local
+        return UserInputRequest.Underlines(blockId = blockId, underlines = local)
+    }
+}
+
+private fun List<Highlight>.withoutHighlightsIn(range: TextRange): List<Highlight> {
+    return filterNot { highlight -> highlight.overlaps(range) }
+}
+
+private fun List<Underline>.underlinesIn(range: TextRange): List<Underline> {
+    return filter { underline -> underline.overlaps(range) }
+}
+
+private fun List<Underline>.withoutUnderlinesIn(range: TextRange): List<Underline> {
+    return filterNot { underline -> underline.overlaps(range) }
+}
+
+private fun Highlight.overlaps(range: TextRange): Boolean {
+    return startIndex in range.min..range.max && endIndex in range.min..range.max ||
+        startIndex <= range.max && endIndex >= range.min
+}
+
+private fun Underline.overlaps(range: TextRange): Boolean {
+    return startIndex in range.min..range.max && endIndex in range.min..range.max ||
+        startIndex <= range.max && endIndex >= range.min
+}

--- a/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/ParagraphUserInputReducerTest.kt
+++ b/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/ParagraphUserInputReducerTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.adventech.blockkit.ui
+
+import androidx.compose.ui.text.TextRange
+import io.adventech.blockkit.model.input.Highlight
+import io.adventech.blockkit.model.input.HighlightColor
+import io.adventech.blockkit.model.input.Underline
+import io.adventech.blockkit.model.input.UserInput
+import io.adventech.blockkit.model.input.UserInputRequest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ParagraphUserInputReducerTest {
+
+    @Test
+    fun `rapid highlight additions include both while repository flow is delayed`() = runTest {
+        val repository = DelayedUserInputRepository()
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.addHighlight(HIGHLIGHT_A))
+        repository.save(reducer.addHighlight(HIGHLIGHT_B))
+
+        assertEquals(listOf(HIGHLIGHT_A), repository.highlightRequest(0).highlights)
+        assertEquals(listOf(HIGHLIGHT_A, HIGHLIGHT_B), repository.highlightRequest(1).highlights)
+        assertEquals(emptyList<UserInput>(), repository.input.value)
+    }
+
+    @Test
+    fun `rapid highlight add then remove retains the new non-overlapping mark`() = runTest {
+        val repository = DelayedUserInputRepository(initialHighlights = listOf(HIGHLIGHT_B))
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.addHighlight(HIGHLIGHT_A))
+        repository.save(reducer.removeHighlights(HIGHLIGHT_B.range))
+
+        assertEquals(listOf(HIGHLIGHT_B, HIGHLIGHT_A), repository.highlightRequest(0).highlights)
+        assertEquals(listOf(HIGHLIGHT_A), repository.highlightRequest(1).highlights)
+    }
+
+    @Test
+    fun `rapid underline additions include both while repository flow is delayed`() = runTest {
+        val repository = DelayedUserInputRepository()
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.toggleUnderline(UNDERLINE_A, UNDERLINE_A.range))
+        repository.save(reducer.toggleUnderline(UNDERLINE_B, UNDERLINE_B.range))
+
+        assertEquals(listOf(UNDERLINE_A), repository.underlineRequest(0).underlines)
+        assertEquals(listOf(UNDERLINE_A, UNDERLINE_B), repository.underlineRequest(1).underlines)
+    }
+
+    @Test
+    fun `rapid underline add then remove retains the new non-overlapping mark`() = runTest {
+        val repository = DelayedUserInputRepository(initialUnderlines = listOf(UNDERLINE_B))
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.toggleUnderline(UNDERLINE_A, UNDERLINE_A.range))
+        repository.save(reducer.removeUnderlines(UNDERLINE_B.range))
+
+        assertEquals(listOf(UNDERLINE_B, UNDERLINE_A), repository.underlineRequest(0).underlines)
+        assertEquals(listOf(UNDERLINE_A), repository.underlineRequest(1).underlines)
+    }
+
+    @Test
+    fun `stale intermediate flow does not roll back the latest local highlight state`() = runTest {
+        val repository = DelayedUserInputRepository()
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.addHighlight(HIGHLIGHT_A))
+        repository.save(reducer.addHighlight(HIGHLIGHT_B))
+
+        repository.emitSaved(0)
+        runCurrent()
+        assertEquals(listOf(HIGHLIGHT_A, HIGHLIGHT_B), reducer.highlights)
+
+        repository.emitSaved(1)
+        runCurrent()
+        assertEquals(listOf(HIGHLIGHT_A, HIGHLIGHT_B), reducer.highlights)
+    }
+
+    @Test
+    fun `acknowledged flow snapshot initializes a recreated reducer without format changes`() = runTest {
+        val repository = DelayedUserInputRepository()
+        val reducer = observeRepository(repository)
+
+        repository.save(reducer.addHighlight(HIGHLIGHT_A))
+        repository.save(reducer.addHighlight(HIGHLIGHT_B))
+        repository.emitSaved(1)
+        runCurrent()
+
+        val recreated = observeRepository(repository)
+        assertEquals(listOf(HIGHLIGHT_A, HIGHLIGHT_B), recreated.highlights)
+        assertEquals(INPUT_ID, repository.highlightInput().id)
+    }
+
+    private fun TestScope.observeRepository(
+        repository: DelayedUserInputRepository,
+    ): ParagraphUserInputReducer {
+        val reducer = ParagraphUserInputReducer(
+            blockId = BLOCK_ID,
+            initialHighlights = emptyList(),
+            initialUnderlines = emptyList(),
+        )
+        backgroundScope.launch {
+            repository.input.collectLatest { input ->
+                reducer.acceptPersistedHighlights(
+                    input.filterIsInstance<UserInput.Highlights>()
+                        .firstOrNull { it.blockId == BLOCK_ID }
+                        ?.highlights
+                        .orEmpty(),
+                )
+                reducer.acceptPersistedUnderlines(
+                    input.filterIsInstance<UserInput.Underlines>()
+                        .firstOrNull { it.blockId == BLOCK_ID }
+                        ?.underlines
+                        .orEmpty(),
+                )
+            }
+        }
+        runCurrent()
+        return reducer
+    }
+
+    private class DelayedUserInputRepository(
+        initialHighlights: List<Highlight> = emptyList(),
+        initialUnderlines: List<Underline> = emptyList(),
+    ) {
+        val input = MutableStateFlow(
+            buildList {
+                if (initialHighlights.isNotEmpty()) {
+                    add(UserInput.Highlights(BLOCK_ID, INPUT_ID, TIMESTAMP, initialHighlights))
+                }
+                if (initialUnderlines.isNotEmpty()) {
+                    add(UserInput.Underlines(BLOCK_ID, INPUT_ID, TIMESTAMP, initialUnderlines))
+                }
+            }
+        )
+        private val requests = mutableListOf<UserInputRequest>()
+
+        fun save(request: UserInputRequest) {
+            requests += request
+        }
+
+        fun emitSaved(index: Int) {
+            val request = requests[index]
+            input.value = input.value.filterNot { persisted ->
+                persisted.blockId == request.blockId &&
+                    (persisted is UserInput.Highlights && request is UserInputRequest.Highlights ||
+                        persisted is UserInput.Underlines && request is UserInputRequest.Underlines)
+            } + when (request) {
+                is UserInputRequest.Highlights -> UserInput.Highlights(
+                    blockId = request.blockId,
+                    id = INPUT_ID,
+                    timestamp = TIMESTAMP,
+                    highlights = request.highlights,
+                )
+                is UserInputRequest.Underlines -> UserInput.Underlines(
+                    blockId = request.blockId,
+                    id = INPUT_ID,
+                    timestamp = TIMESTAMP,
+                    underlines = request.underlines,
+                )
+                else -> error("Unsupported request: ${request::class.simpleName}")
+            }
+        }
+
+        fun highlightRequest(index: Int): UserInputRequest.Highlights {
+            return requests.filterIsInstance<UserInputRequest.Highlights>()[index]
+        }
+
+        fun underlineRequest(index: Int): UserInputRequest.Underlines {
+            return requests.filterIsInstance<UserInputRequest.Underlines>()[index]
+        }
+
+        fun highlightInput(): UserInput.Highlights {
+            return input.value.filterIsInstance<UserInput.Highlights>().single()
+        }
+    }
+
+    private companion object {
+        const val BLOCK_ID = "paragraph-block"
+        const val INPUT_ID = "stable-input-id"
+        const val TIMESTAMP = 1_735_689_600_000L
+        val HIGHLIGHT_A = Highlight(0, 4, 4, HighlightColor.YELLOW)
+        val HIGHLIGHT_B = Highlight(10, 14, 4, HighlightColor.BLUE)
+        val UNDERLINE_A = Underline(0, 4, 4, HighlightColor.YELLOW)
+        val UNDERLINE_B = Underline(10, 14, 4, HighlightColor.BLUE)
+
+        val Highlight.range: TextRange
+            get() = TextRange(startIndex, endIndex)
+
+        val Underline.range: TextRange
+            get() = TextRange(startIndex, endIndex)
+    }
+}


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0001

## Proposed PR

- Suggested title: `fix(block-kit): serialize paragraph mark mutations`
- Upstream target: `Adventech/sabbath-school-android` / `main`
- Audited and last revalidated public base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Published fork branch: `fix/adv-2026-0001-serialized-user-input`
- Published fork head: `d30459f63f8f1a7d3dac352bf8e3ecead628309c`
- Shape: one commit, sole parent is the base above; one root only (`RC-0001`)
- State: published as draft PR [#1549](https://github.com/Adventech/sabbath-school-android/pull/1549) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity before review. Its source tree, message, parent, and stable patch ID are unchanged, so the recorded source-tree validation remains applicable to the published head.

## Why

`ParagraphContent.SelectableParagraph` rendered optimistic highlight and underline state, but each subsequent mutation rebuilt its full persisted snapshot from a lagging repository `Flow`. Two rapid changes could therefore save only the second mark, while add-then-remove could drop an unrelated newer mark. This is a confirmed P0 data-loss path in Android issue #1545.

## Failing-before reproduction

Run the focused reducer test against the audited base behavior:

```powershell
.\gradlew.bat :libraries:block-kit:ui:testReleaseUnitTest --tests 'io.adventech.blockkit.ui.ParagraphUserInputReducerTest' --stacktrace --no-daemon
```

The pre-fix delayed-`MutableStateFlow` fixture records four behavioral failures: rapid highlight add/add saves `[B]` instead of `[A, B]`; highlight add/remove saves `[]` instead of `[A]`; and the equivalent two underline cases fail the same way. The repository deliberately withholds acknowledgement, proving the overwrite occurs at the UI snapshot boundary.

## Minimal fix

- Add one in-memory `ParagraphUserInputReducer` per composed paragraph.
- Reduce add/remove/toggle synchronously from the latest optimistic highlight or underline list.
- Treat only an exact matching persisted emission as acknowledgement; ignore stale intermediate emissions while a newer list is pending.
- Preserve the existing request models, stable IDs, timestamps, ordering, and repository/API behavior.

Changed paths are limited to `ParagraphContent.kt`, the new reducer, and its focused test. No Room entity, schema, migration, API, content, localization, workflow, signing, or deployment file changes.

## Recorded local checks

- Expected RED: focused delayed-flow test, 4 tests and 4 failures.
- PASS after fix: focused reducer suite, 6/6.
- PASS: `:libraries:block-kit:ui:check :libraries:block-kit:ui:assembleRelease :features:document:check :features:document:assembleRelease` (943 actionable tasks).
- PASS: final committed `:libraries:block-kit:ui:check :features:document:check`; XML aggregates report block-kit UI 25/25 and document 4/4.
- PASS: `:app:assembleRelease` on the local source.
- PASS: `git show --check HEAD`, clean worktree, and base/merge-base comparison.

These are local Windows-hosted Gradle results plus the bounded API 35 AOSP evidence below. No hosted Actions, physical-device, signing, store, release, deployment, or production result is claimed.

The 2026-07-28 delivery refresh reconfirmed that public `main` and PR #1548 are unchanged. On the exact recorded head, the focused reducer rerun passed 6/6, the affected release matrix passed 29/29 across 11 XML suites, and a fresh `:app:assembleRelease --rerun-tasks` produced the local unsigned APK. The branch remains clean and directly based on `55405f66a…`; this refresh does not satisfy the still-unavailable device or hosted gates.

## API 35 production-path evidence (2026-07-30)

An equal, unpushed evidence harness now exercises the real production UI-to-event path. Exact-base child `aed40ade1c57379cda1c457cb15a2fa38cb18501` and exact-PR-head child `b4aa69005afba848fe1a6d18e3ae2c716db3dbbd` share raw stable patch ID `181d81dde0bca4f7dee4fc9122b991e7750a2927`. Both target-35 APKs build successfully; the fixed evidence child also passes Spotless.

The harness renders production `BlockContent`, selects exact ranges through public Compose semantics, opens Android's native localized ActionMode, clicks Highlight/Underline through UiAutomator, and captures only production `InputChanged` events. On a clean isolated base install, the single-highlight positive control passes; rapid highlight and rapid underline each emit `[A]`, then `[B]` instead of `[A]`, then `[A,B]`. The exact PR-head APK passes the combined suite 3/3 and all three isolated cases. Canonical public-safe log SHA-256: `B66D09F3351D3FC2BDAA6BFE324513B4703CCD521CC49E9FD7E1AEEBE555CF0E`.

These evidence refs are local-only and excluded from delivery credit. This closes only the scoped API 35 Compose/native-menu mutation path; it does not prove Activity/process death, Room/network/offline/cross-device durability, minimum/current APIs, physical devices, signing/store delivery, hosted CI, merge, release, deployment, or observation.
## Overlap and disposition

The only current Android PR, #1548 at `8523d93c0f05376b30113a2b24c1f7bbccc30aa0`, changes only `DocumentScreenUi.kt` for screen timeout and has zero file/root overlap. Keep it separate; its exact head is independently unbuildable and must be amended as recorded in the PR matrix.

RC-0001 is file-disjoint from RC-0002 and RC-0003. The verification-only Android stack proves combined tests pass, but its head is not publishable.

## Migration, recovery, and rollback

- No schema or wire migration is required; persisted model blobs and IDs remain unchanged.
- A reducer re-created after Room acknowledgement hydrates the same stored list and stable ID.
- The in-memory interval before the repository persists a request remains outside this root; RC-0002 owns durable retry/process-restart behavior.
- Previously overwritten marks cannot be reconstructed without a trusted server/device backup. Never replace newer local input during recovery.
- Binary rollback is format-compatible but restores the confirmed overwrite. Prefer a forward fix or temporarily disable mark mutation controls; do not return callbacks to lagging-flow reduction.

## Security, privacy, and content rights

Highlights and underlines reveal private reading behavior. The patch adds no payload logging, telemetry, permission, network field, user data, translation, lesson, PDF, video, Bible/EGW material, or other rights-controlled content.

## Dependency order and draft blockers

This root is independently publishable and should precede the storage/sync stack. The scoped API 35 rapid-mark UI path now has equal-harness red/green evidence; keep the PR draft until maintainers run background/foreground and process-kill cases before/after Room acknowledgement, offline/authenticated operation, minimum/current APIs, representative physical devices, signing/store validation, and required hosted checks. Rebase and rerun all checks if `main` moves.

