### PR TITLE
fix(storage): preserve v26 legacy user input

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstall
 androidx-room = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
 androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "androidx-tv" }
 androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "androidx-tv-material" }

--- a/libraries/storage/api/src/main/kotlin/ss/libraries/storage/api/dao/UserInputDao.kt
+++ b/libraries/storage/api/src/main/kotlin/ss/libraries/storage/api/dao/UserInputDao.kt
@@ -24,6 +24,7 @@ package ss.libraries.storage.api.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import ss.libraries.storage.api.entity.UserInputEntity
 
@@ -36,6 +37,23 @@ interface UserInputDao : BaseDao<UserInputEntity> {
     @Query("SELECT id FROM user_input WHERE localId = :localId")
     fun getId(localId: String): String?
 
+    @Transaction
+    fun clear() {
+        clearCurrent()
+        clearLegacyAnnotations()
+        clearLegacyComments()
+        clearLegacyHighlights()
+    }
+
     @Query("DELETE FROM user_input")
-    fun clear()
+    fun clearCurrent()
+
+    @Query("DELETE FROM legacy_annotations_v26")
+    fun clearLegacyAnnotations()
+
+    @Query("DELETE FROM legacy_comments_v26")
+    fun clearLegacyComments()
+
+    @Query("DELETE FROM legacy_highlights_v26")
+    fun clearLegacyHighlights()
 }

--- a/libraries/storage/api/src/main/kotlin/ss/libraries/storage/api/entity/LegacyUserInputEntities.kt
+++ b/libraries/storage/api/src/main/kotlin/ss/libraries/storage/api/entity/LegacyUserInputEntities.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025. Adventech <info@adventech.io>
+ * Copyright (c) 2026. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,32 +20,34 @@
  * THE SOFTWARE.
  */
 
-package app.ss.storage.test
+package ss.libraries.storage.api.entity
 
-import androidx.annotation.VisibleForTesting
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
-import ss.libraries.storage.api.dao.UserInputDao
-import ss.libraries.storage.api.entity.UserInputEntity
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-@VisibleForTesting(otherwise = VisibleForTesting.NONE)
-class FakeUserInputDao : FakeBaseDao<UserInputEntity>(), UserInputDao {
+@Entity(tableName = "legacy_annotations_v26")
+data class LegacyPdfAnnotationsV26Entity(
+    @PrimaryKey val index: String,
+    val pdfIndex: String,
+    val pageIndex: Int,
+    val annotations: String,
+    @ColumnInfo(defaultValue = "1675209600")
+    val timestamp: Long,
+)
 
-    override fun getDocumentInput(documentId: String): Flow<List<UserInputEntity>> {
-        return flowOf(items.toList().filter { it.documentId == documentId })
-    }
+@Entity(tableName = "legacy_comments_v26")
+data class LegacyReadCommentsV26Entity(
+    @PrimaryKey val readIndex: String,
+    val comments: String,
+    @ColumnInfo(defaultValue = "1675209600")
+    val timestamp: Long,
+)
 
-    override fun getId(localId: String): String? {
-        return items.find { it.localId == localId }?.id
-    }
-
-    override fun clearCurrent() {
-        items.clear()
-    }
-
-    override fun clearLegacyAnnotations() = Unit
-
-    override fun clearLegacyComments() = Unit
-
-    override fun clearLegacyHighlights() = Unit
-}
+@Entity(tableName = "legacy_highlights_v26")
+data class LegacyReadHighlightsV26Entity(
+    @PrimaryKey val readIndex: String,
+    val highlights: String,
+    @ColumnInfo(defaultValue = "1675209600")
+    val timestamp: Long,
+)

--- a/services/storage/impl/build.gradle.kts
+++ b/services/storage/impl/build.gradle.kts
@@ -31,7 +31,10 @@ plugins {
 
 extensions.configure<LibraryExtension> {
     namespace = "ss.services.storage.impl"
+    sourceSets.getByName("test").assets.directories.add("schemas")
 }
+
+foundry { android { features { robolectric() } } }
 
 ksp { arg("room.schemaLocation", "$projectDir/schemas") }
 
@@ -44,6 +47,9 @@ dependencies {
     implementation(libs.moshix.adapters)
     implementation(libs.square.moshi.kotlin)
     implementation(libs.timber)
+
+    testImplementation(libs.androidx.room.testing)
+    testImplementation(libs.bundles.testing.common)
 
     ksp(libs.androidx.room.compiler)
     ksp(libs.google.hilt.compiler)

--- a/services/storage/impl/schemas/ss.services.storage.impl.SabbathSchoolDatabase/33.json
+++ b/services/storage/impl/schemas/ss.services.storage.impl.SabbathSchoolDatabase/33.json
@@ -1,0 +1,1421 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "b10c642108ca73c87207571240a02ab2",
+    "entities": [
+      {
+        "tableName": "audios",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artist` TEXT NOT NULL, `image` TEXT NOT NULL, `imageRatio` TEXT NOT NULL, `src` TEXT NOT NULL, `target` TEXT NOT NULL, `targetIndex` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageRatio",
+            "columnName": "imageRatio",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "src",
+            "columnName": "src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetIndex",
+            "columnName": "targetIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "languages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`code` TEXT NOT NULL, `name` TEXT NOT NULL, `nativeName` TEXT NOT NULL DEFAULT '', `devo` INTEGER NOT NULL DEFAULT 0, `pm` INTEGER NOT NULL DEFAULT 0, `aij` INTEGER NOT NULL DEFAULT 0, `ss` INTEGER NOT NULL DEFAULT 1, `explore` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`code`))",
+        "fields": [
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nativeName",
+            "columnName": "nativeName",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "devo",
+            "columnName": "devo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pm",
+            "columnName": "pm",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aij",
+            "columnName": "aij",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "ss",
+            "columnName": "ss",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "explore",
+            "columnName": "explore",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "code"
+          ]
+        }
+      },
+      {
+        "tableName": "quarterlies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`index` TEXT NOT NULL, `id` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `introduction` TEXT, `human_date` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `cover` TEXT NOT NULL, `splash` TEXT, `path` TEXT NOT NULL, `full_path` TEXT NOT NULL, `lang` TEXT NOT NULL, `color_primary` TEXT NOT NULL, `color_primary_dark` TEXT NOT NULL, `quarterly_name` TEXT NOT NULL, `quarterly_group` TEXT, `features` TEXT NOT NULL, `credits` TEXT NOT NULL, `offlineState` TEXT NOT NULL DEFAULT 'NONE', PRIMARY KEY(`index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "introduction",
+            "columnName": "introduction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "human_date",
+            "columnName": "human_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start_date",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "end_date",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splash",
+            "columnName": "splash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "full_path",
+            "columnName": "full_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color_primary",
+            "columnName": "color_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color_primary_dark",
+            "columnName": "color_primary_dark",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quarterly_name",
+            "columnName": "quarterly_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quarterly_group",
+            "columnName": "quarterly_group",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "features",
+            "columnName": "features",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "credits",
+            "columnName": "credits",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offlineState",
+            "columnName": "offlineState",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "index"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`index` TEXT NOT NULL, `quarter` TEXT NOT NULL, `title` TEXT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `cover` TEXT NOT NULL, `id` TEXT NOT NULL, `path` TEXT NOT NULL, `full_path` TEXT NOT NULL, `pdfOnly` INTEGER NOT NULL, `days` TEXT NOT NULL, `pdfs` TEXT NOT NULL, `order` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quarter",
+            "columnName": "quarter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start_date",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "end_date",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "full_path",
+            "columnName": "full_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pdfOnly",
+            "columnName": "pdfOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "days",
+            "columnName": "days",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pdfs",
+            "columnName": "pdfs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "index"
+          ]
+        }
+      },
+      {
+        "tableName": "reads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`index` TEXT NOT NULL, `id` TEXT NOT NULL, `date` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `bible` TEXT NOT NULL, PRIMARY KEY(`index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bible",
+            "columnName": "bible",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "index"
+          ]
+        }
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` TEXT NOT NULL, `displayName` TEXT, `email` TEXT, `photo` TEXT, `emailVerified` INTEGER NOT NULL, `phoneNumber` TEXT, `isAnonymous` INTEGER NOT NULL, `tenantId` TEXT, `stsTokenManager` TEXT NOT NULL, PRIMARY KEY(`uid`))",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "photo",
+            "columnName": "photo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emailVerified",
+            "columnName": "emailVerified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAnonymous",
+            "columnName": "isAnonymous",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tenantId",
+            "columnName": "tenantId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stsTokenManager",
+            "columnName": "stsTokenManager",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uid"
+          ]
+        }
+      },
+      {
+        "tableName": "video_clips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `artist` TEXT NOT NULL, `src` TEXT NOT NULL, `target` TEXT NOT NULL, `targetIndex` TEXT NOT NULL, `thumbnail` TEXT NOT NULL, `title` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "src",
+            "columnName": "src",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetIndex",
+            "columnName": "targetIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lessonIndex` TEXT NOT NULL, `artist` TEXT NOT NULL, `clips` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonIndex",
+            "columnName": "lessonIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clips",
+            "columnName": "clips",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "publishing_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `country` TEXT NOT NULL, `language` TEXT NOT NULL, `message` TEXT NOT NULL, `url` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "bible_version",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`language` TEXT NOT NULL, `version` TEXT NOT NULL, PRIMARY KEY(`language`))",
+        "fields": [
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "language"
+          ]
+        }
+      },
+      {
+        "tableName": "app_widget",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`quarterlyIndex` TEXT NOT NULL, `cover` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `days` TEXT NOT NULL, PRIMARY KEY(`quarterlyIndex`))",
+        "fields": [
+          {
+            "fieldPath": "quarterlyIndex",
+            "columnName": "quarterlyIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "days",
+            "columnName": "days",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "quarterlyIndex"
+          ]
+        }
+      },
+      {
+        "tableName": "font_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fileName` TEXT NOT NULL, `name` TEXT NOT NULL, `attributes` TEXT NOT NULL DEFAULT 'UNKNOWN', PRIMARY KEY(`fileName`))",
+        "fields": [
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributes",
+            "columnName": "attributes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'UNKNOWN'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fileName"
+          ]
+        }
+      },
+      {
+        "tableName": "segments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `index` TEXT NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, `type` TEXT NOT NULL, `resourceId` TEXT NOT NULL, `markdownTitle` TEXT, `subtitle` TEXT, `markdownSubtitle` TEXT, `titleBelowCover` INTEGER, `cover` TEXT, `date` TEXT, `background` TEXT, `pdf` TEXT, `video` TEXT, `style` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markdownTitle",
+            "columnName": "markdownTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "markdownSubtitle",
+            "columnName": "markdownSubtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleBelowCover",
+            "columnName": "titleBelowCover",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "background",
+            "columnName": "background",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pdf",
+            "columnName": "pdf",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "video",
+            "columnName": "video",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "style",
+            "columnName": "style",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_input",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `id` TEXT, `documentId` TEXT NOT NULL, `input` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`localId`))",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "documentId",
+            "columnName": "documentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "input",
+            "columnName": "input",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        }
+      },
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `index` TEXT NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `resourceId` TEXT NOT NULL, `resourceIndex` TEXT NOT NULL, `sequence` TEXT NOT NULL, `cover` TEXT, `startDate` TEXT, `endDate` TEXT, `segments` TEXT, `showSegmentChips` INTEGER, `titleBelowCover` INTEGER, `externalURL` TEXT, `segmentChipsStyle` TEXT, `style` TEXT, `share` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resourceId",
+            "columnName": "resourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourceIndex",
+            "columnName": "resourceIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segments",
+            "columnName": "segments",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showSegmentChips",
+            "columnName": "showSegmentChips",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "titleBelowCover",
+            "columnName": "titleBelowCover",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalURL",
+            "columnName": "externalURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentChipsStyle",
+            "columnName": "segmentChipsStyle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "style",
+            "columnName": "style",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "share",
+            "columnName": "share",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "resources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, `markdownTitle` TEXT, `startDate` TEXT, `endDate` TEXT, `description` TEXT, `markdownDescription` TEXT, `introduction` TEXT, `index` TEXT NOT NULL, `type` TEXT NOT NULL, `credits` TEXT NOT NULL, `features` TEXT NOT NULL, `primaryColor` TEXT NOT NULL, `primaryColorDark` TEXT NOT NULL, `subtitle` TEXT, `markdownSubtitle` TEXT, `covers` TEXT NOT NULL, `kind` TEXT NOT NULL, `sectionView` TEXT, `sections` TEXT, `cta` TEXT, `preferredCover` TEXT, `fonts` TEXT, `style` TEXT, `progressTracking` TEXT, `downloadable` INTEGER, `share` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "markdownTitle",
+            "columnName": "markdownTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "markdownDescription",
+            "columnName": "markdownDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "introduction",
+            "columnName": "introduction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "credits",
+            "columnName": "credits",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "features",
+            "columnName": "features",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColor",
+            "columnName": "primaryColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColorDark",
+            "columnName": "primaryColorDark",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "markdownSubtitle",
+            "columnName": "markdownSubtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "covers",
+            "columnName": "covers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionView",
+            "columnName": "sectionView",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sections",
+            "columnName": "sections",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cta",
+            "columnName": "cta",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preferredCover",
+            "columnName": "preferredCover",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fonts",
+            "columnName": "fonts",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "style",
+            "columnName": "style",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progressTracking",
+            "columnName": "progressTracking",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadable",
+            "columnName": "downloadable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "share",
+            "columnName": "share",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `language` TEXT NOT NULL, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `groups` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groups",
+            "columnName": "groups",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feed_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `scope` TEXT NOT NULL, `direction` TEXT NOT NULL, `title` TEXT, `view` TEXT NOT NULL, `resources` TEXT, `seeAll` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "view",
+            "columnName": "view",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resources",
+            "columnName": "resources",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seeAll",
+            "columnName": "seeAll",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "quarterly_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `index` TEXT NOT NULL, `language` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "block_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `segmentId` TEXT NOT NULL, `order` INTEGER NOT NULL, `item` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`segmentId`) REFERENCES `segments`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "segmentId",
+            "columnName": "segmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_block_items_segmentId",
+            "unique": false,
+            "columnNames": [
+              "segmentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_block_items_segmentId` ON `${TABLE_NAME}` (`segmentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "segments",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "segmentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "legacy_annotations_v26",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`index` TEXT NOT NULL, `pdfIndex` TEXT NOT NULL, `pageIndex` INTEGER NOT NULL, `annotations` TEXT NOT NULL, `timestamp` INTEGER NOT NULL DEFAULT 1675209600, PRIMARY KEY(`index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pdfIndex",
+            "columnName": "pdfIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageIndex",
+            "columnName": "pageIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "annotations",
+            "columnName": "annotations",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1675209600"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "index"
+          ]
+        }
+      },
+      {
+        "tableName": "legacy_comments_v26",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`readIndex` TEXT NOT NULL, `comments` TEXT NOT NULL, `timestamp` INTEGER NOT NULL DEFAULT 1675209600, PRIMARY KEY(`readIndex`))",
+        "fields": [
+          {
+            "fieldPath": "readIndex",
+            "columnName": "readIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comments",
+            "columnName": "comments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1675209600"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "readIndex"
+          ]
+        }
+      },
+      {
+        "tableName": "legacy_highlights_v26",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`readIndex` TEXT NOT NULL, `highlights` TEXT NOT NULL, `timestamp` INTEGER NOT NULL DEFAULT 1675209600, PRIMARY KEY(`readIndex`))",
+        "fields": [
+          {
+            "fieldPath": "readIndex",
+            "columnName": "readIndex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlights",
+            "columnName": "highlights",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1675209600"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "readIndex"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b10c642108ca73c87207571240a02ab2')"
+    ]
+  }
+}

--- a/services/storage/impl/src/main/kotlin/ss/services/storage/impl/SabbathSchoolDatabase.kt
+++ b/services/storage/impl/src/main/kotlin/ss/services/storage/impl/SabbathSchoolDatabase.kt
@@ -57,6 +57,9 @@ import ss.libraries.storage.api.entity.FeedEntity
 import ss.libraries.storage.api.entity.FeedGroupEntity
 import ss.libraries.storage.api.entity.FontFileEntity
 import ss.libraries.storage.api.entity.LanguageEntity
+import ss.libraries.storage.api.entity.LegacyPdfAnnotationsV26Entity
+import ss.libraries.storage.api.entity.LegacyReadCommentsV26Entity
+import ss.libraries.storage.api.entity.LegacyReadHighlightsV26Entity
 import ss.libraries.storage.api.entity.LessonEntity
 import ss.libraries.storage.api.entity.PublishingInfoEntity
 import ss.libraries.storage.api.entity.QuarterlyEntity
@@ -93,8 +96,11 @@ import ss.services.storage.impl.migration.LegacyUserInputMigration
         FeedGroupEntity::class,
         QuarterlyIndexEntity::class,
         BlockItemEntity::class,
+        LegacyPdfAnnotationsV26Entity::class,
+        LegacyReadCommentsV26Entity::class,
+        LegacyReadHighlightsV26Entity::class,
     ],
-    version = 32,
+    version = 33,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -121,12 +127,12 @@ import ss.services.storage.impl.migration.LegacyUserInputMigration
         AutoMigration(from = 23, to = 24),
         AutoMigration(from = 24, to = 25),
         AutoMigration(from = 25, to = 26),
-        AutoMigration(from = 26, to = 27, spec = LegacyUserInputMigration::class),
         AutoMigration(from = 27, to = 28),
         AutoMigration(from = 28, to = 29),
         AutoMigration(from = 29, to = 30),
         AutoMigration(from = 30, to = 31),
         AutoMigration(from = 31, to = 32, spec = LegacySegmentsMigration::class),
+        AutoMigration(from = 32, to = 33),
     ]
 )
 @TypeConverters(Converters::class, ResourcesConverters::class)
@@ -183,7 +189,7 @@ internal abstract class SabbathSchoolDatabase : RoomDatabase() {
 
         private fun buildDatabase(context: Context): SabbathSchoolDatabase =
             Room.databaseBuilder(context, SabbathSchoolDatabase::class.java, DATABASE_NAME)
-                .fallbackToDestructiveMigration(dropAllTables = true)
+                .addMigrations(LegacyUserInputMigration)
                 .setQueryCoroutineContext(Dispatchers.IO)
                 .build()
     }

--- a/services/storage/impl/src/main/kotlin/ss/services/storage/impl/migration/LegacyUserInputMigration.kt
+++ b/services/storage/impl/src/main/kotlin/ss/services/storage/impl/migration/LegacyUserInputMigration.kt
@@ -22,10 +22,21 @@
 
 package ss.services.storage.impl.migration
 
-import androidx.room.DeleteTable
-import androidx.room.migration.AutoMigrationSpec
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@DeleteTable(tableName = "annotations")
-@DeleteTable(tableName = "comments")
-@DeleteTable(tableName = "highlights")
-class LegacyUserInputMigration: AutoMigrationSpec
+/**
+ * Losslessly quarantines legacy user input whose identifiers and payload formats cannot be safely
+ * mapped to the block-based user input model during a SQL migration.
+ *
+ * These tables are isolated from the active user input model but remain managed recovery tables so
+ * they follow the same logout and account-deletion cleanup lifecycle.
+ */
+internal object LegacyUserInputMigration : Migration(26, 27) {
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `annotations` RENAME TO `legacy_annotations_v26`")
+        db.execSQL("ALTER TABLE `comments` RENAME TO `legacy_comments_v26`")
+        db.execSQL("ALTER TABLE `highlights` RENAME TO `legacy_highlights_v26`")
+    }
+}

--- a/services/storage/impl/src/test/kotlin/ss/services/storage/impl/migration/LegacyUserInputMigrationTest.kt
+++ b/services/storage/impl/src/test/kotlin/ss/services/storage/impl/migration/LegacyUserInputMigrationTest.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package ss.services.storage.impl.migration
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import ss.services.storage.impl.SabbathSchoolDatabase
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class LegacyUserInputMigrationTest {
+
+    private val testDatabase: String by lazy {
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext
+            .getDatabasePath(TEST_DATABASE_FILENAME)
+            .absolutePath
+    }
+
+    @get:Rule
+    val migrationHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        SabbathSchoolDatabase::class.java,
+    )
+
+    @Test
+    fun `migration preserves legacy payloads until user input is cleared`() {
+        migrationHelper.createDatabase(testDatabase, 26).use { database ->
+            database.seedVersion26UserInput()
+        }
+
+        val migrated = migrationHelper.runMigrationsAndValidate(
+            testDatabase,
+            CURRENT_DATABASE_VERSION,
+            true,
+            LegacyUserInputMigration,
+        )
+
+        migrated.use { database ->
+            database.assertLegacyAnnotationsPreserved()
+            database.assertLegacyCommentsPreserved()
+            database.assertLegacyHighlightsPreserved()
+            database.assertCurrentUserInputPreserved()
+            assertFalse(database.hasTable("annotations"))
+            assertFalse(database.hasTable("comments"))
+            assertFalse(database.hasTable("highlights"))
+        }
+
+        val database = Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            SabbathSchoolDatabase::class.java,
+            testDatabase,
+        )
+            .addMigrations(LegacyUserInputMigration)
+            .allowMainThreadQueries()
+            .build()
+        try {
+            database.userInputDao().clear()
+            database.openHelper.writableDatabase.assertAllUserInputCleared()
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun SupportSQLiteDatabase.seedVersion26UserInput() {
+        execSQL(
+            """
+            INSERT INTO annotations (`index`, `pdfIndex`, `pageIndex`, `annotations`, `timestamp`)
+            VALUES (?, ?, ?, ?, ?)
+            """.trimIndent(),
+            arrayOf<Any>(ANNOTATION_INDEX, PDF_INDEX, PAGE_INDEX, ANNOTATIONS_PAYLOAD, ANNOTATIONS_TIMESTAMP),
+        )
+        execSQL(
+            """
+            INSERT INTO comments (`readIndex`, `comments`, `timestamp`)
+            VALUES (?, ?, ?)
+            """.trimIndent(),
+            arrayOf<Any>(READ_INDEX, COMMENTS_PAYLOAD, COMMENTS_TIMESTAMP),
+        )
+        execSQL(
+            """
+            INSERT INTO highlights (`readIndex`, `highlights`, `timestamp`)
+            VALUES (?, ?, ?)
+            """.trimIndent(),
+            arrayOf<Any>(READ_INDEX, HIGHLIGHTS_PAYLOAD, HIGHLIGHTS_TIMESTAMP),
+        )
+        execSQL(
+            """
+            INSERT INTO user_input (`localId`, `id`, `documentId`, `input`, `timestamp`)
+            VALUES (?, ?, ?, ?, ?)
+            """.trimIndent(),
+            arrayOf<Any>(USER_INPUT_LOCAL_ID, USER_INPUT_ID, DOCUMENT_ID, USER_INPUT_PAYLOAD, USER_INPUT_TIMESTAMP),
+        )
+    }
+
+    private fun SupportSQLiteDatabase.assertLegacyAnnotationsPreserved() {
+        query(
+            """
+            SELECT `index`, `pdfIndex`, `pageIndex`, `annotations`, `timestamp`
+            FROM `legacy_annotations_v26`
+            """.trimIndent()
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(ANNOTATION_INDEX, cursor.getString(0))
+            assertEquals(PDF_INDEX, cursor.getString(1))
+            assertEquals(PAGE_INDEX, cursor.getInt(2))
+            assertEquals(ANNOTATIONS_PAYLOAD, cursor.getString(3))
+            assertEquals(ANNOTATIONS_TIMESTAMP, cursor.getLong(4))
+            assertFalse(cursor.moveToNext())
+        }
+    }
+
+    private fun SupportSQLiteDatabase.assertLegacyCommentsPreserved() {
+        query(
+            """
+            SELECT `readIndex`, `comments`, `timestamp`
+            FROM `legacy_comments_v26`
+            """.trimIndent()
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(READ_INDEX, cursor.getString(0))
+            assertEquals(COMMENTS_PAYLOAD, cursor.getString(1))
+            assertEquals(COMMENTS_TIMESTAMP, cursor.getLong(2))
+            assertFalse(cursor.moveToNext())
+        }
+    }
+
+    private fun SupportSQLiteDatabase.assertLegacyHighlightsPreserved() {
+        query(
+            """
+            SELECT `readIndex`, `highlights`, `timestamp`
+            FROM `legacy_highlights_v26`
+            """.trimIndent()
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(READ_INDEX, cursor.getString(0))
+            assertEquals(HIGHLIGHTS_PAYLOAD, cursor.getString(1))
+            assertEquals(HIGHLIGHTS_TIMESTAMP, cursor.getLong(2))
+            assertFalse(cursor.moveToNext())
+        }
+    }
+
+    private fun SupportSQLiteDatabase.assertCurrentUserInputPreserved() {
+        query(
+            """
+            SELECT `localId`, `id`, `documentId`, `input`, `timestamp`
+            FROM `user_input`
+            """.trimIndent()
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(USER_INPUT_LOCAL_ID, cursor.getString(0))
+            assertEquals(USER_INPUT_ID, cursor.getString(1))
+            assertEquals(DOCUMENT_ID, cursor.getString(2))
+            assertEquals(USER_INPUT_PAYLOAD, cursor.getString(3))
+            assertEquals(USER_INPUT_TIMESTAMP, cursor.getLong(4))
+            assertFalse(cursor.moveToNext())
+        }
+    }
+
+    private fun SupportSQLiteDatabase.assertAllUserInputCleared() {
+        assertEquals(0, rowCount("user_input"))
+        assertEquals(0, rowCount("legacy_annotations_v26"))
+        assertEquals(0, rowCount("legacy_comments_v26"))
+        assertEquals(0, rowCount("legacy_highlights_v26"))
+    }
+
+    private fun SupportSQLiteDatabase.rowCount(tableName: String): Int =
+        query("SELECT COUNT(*) FROM `$tableName`").use { cursor ->
+            cursor.moveToFirst()
+            cursor.getInt(0)
+        }
+
+    private fun SupportSQLiteDatabase.hasTable(tableName: String): Boolean =
+        query(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)",
+            arrayOf(tableName),
+        ).use { cursor ->
+            cursor.moveToFirst()
+            cursor.getInt(0) == 1
+        }
+
+    private companion object {
+        const val TEST_DATABASE_FILENAME = "legacy-user-input-migration-test"
+        const val CURRENT_DATABASE_VERSION = 33
+        const val ANNOTATION_INDEX = "2025-q1-lesson-1-en-pdf-a-7"
+        const val PDF_INDEX = "2025-q1-lesson-1-en-pdf-a"
+        const val PAGE_INDEX = 7
+        const val ANNOTATIONS_PAYLOAD = """["annotation naïve Библия 漢字 \"quoted\""]"""
+        const val ANNOTATIONS_TIMESTAMP = 1_735_689_601_001L
+        const val READ_INDEX = "en-2025-01-01-ß"
+        const val COMMENTS_PAYLOAD =
+            """[{"elementId":"question-Ț-1","comment":"Б & <tag> — keep offline"}]"""
+        const val COMMENTS_TIMESTAMP = 1_735_689_602_002L
+        const val HIGHLIGHTS_PAYLOAD =
+            """{"version":1,"highlights":["a[href='#Б']","span[data-id='漢字']"]}"""
+        const val HIGHLIGHTS_TIMESTAMP = 1_735_689_603_003L
+        const val USER_INPUT_LOCAL_ID = "document-current-comments-block-current"
+        const val USER_INPUT_ID = "remote-input-id"
+        const val DOCUMENT_ID = "document-current"
+        const val USER_INPUT_PAYLOAD =
+            """{"inputType":"comments","blockId":"block-current","id":"remote-input-id","timestamp":1735689604004,"comment":"already migrated"}"""
+        const val USER_INPUT_TIMESTAMP = 1_735_689_604_004L
+    }
+}


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0003

## Proposed PR

- Suggested title: `fix(storage): preserve v26 legacy user input`
- Upstream target: `Adventech/sabbath-school-android` / `main`
- Audited and last revalidated public base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Published fork branch: `fix/adv-2026-0003-v26-migration`
- Published fork head: `420ecbb013c957c99b73b6916163056ae2362361`
- Shape: one commit, sole parent is the base above; one root only (`RC-0003`)
- State: published as draft PR [#1550](https://github.com/Adventech/sabbath-school-android/pull/1550) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity before review. Its source tree, message, parent, and stable patch ID are unchanged, so the recorded source-tree validation remains applicable to the published head.

## Why

The production v26-to-v27 Room migration deleted the durable `annotations`, `comments`, and `highlights` tables. A global destructive fallback could erase the complete database on unsupported paths. The old identifiers do not prove a safe semantic mapping into current block-level input, so the minimal data-preserving remedy quarantines the original rows byte-for-byte rather than guessing. This is a confirmed P0 slice of Android issue #1545.

## Failing-before reproduction

```powershell
.\gradlew.bat :services:storage:impl:testReleaseUnitTest --tests 'ss.services.storage.impl.migration.LegacyUserInputMigrationTest' --stacktrace --no-daemon
```

With a populated v26 database, the initial migration test fails because `legacy_annotations_v26` does not exist after migration. A second deliberate red privacy phase observes one retained legacy row after the real `UserInputDao.clear()`, proving recovery tables also need account-deletion/logout semantics.

## Minimal fix

- Replace the destructive 26-to-27 auto-migration with a transaction that renames all three tables to managed `legacy_*_v26` recovery tables.
- Declare exact Room entities matching the v26 columns, types, defaults, nullability, and keys.
- Add the recovery tables to version 33, remove destructive fallback, and fail closed on missing migration paths.
- Clear modern and quarantined input together in the real DAO transaction.
- Defer semantic import until maintainers provide a verified ID/payload corpus.

## Recorded local checks

- Expected RED: populated v26 migration loses the recovery table; privacy red leaves a legacy row after `clear()`.
- PASS: focused real Room/Robolectric migration and privacy test.
- PASS: `:services:storage:impl:check :services:storage:impl:assembleRelease :common:auth:testReleaseUnitTest` (297 tasks).
- PASS: `:libraries:storage:api:check :libraries:storage:test:check :common:auth:check` (368 tasks).
- PASS: `:app:assembleRelease` (1,200 tasks).
- PASS: exact v26 source/recovery schema comparison, diff check, clean tree, and base/merge-base comparison.
- PASS in the verification-only RC-0001/0003/0002 stack: both real migration suites and combined 37/37 tests.

These are local Windows-hosted Robolectric/SQLite/Gradle results. No hosted Actions, production database, emulator, physical-device, signed, store, or production result is claimed.

The 2026-07-28 delivery refresh reconfirmed the unchanged public target and zero-overlap PR set. The exact clean head passed the real migration fixture (1/1), the 297-task storage/auth release gate (5/5 emitted tests), the storage compatibility gate (4/4 emitted tests), and a restarted fresh `:app:assembleRelease --rerun-tasks`. This refresh adds local delivery confidence only; it does not satisfy the production-signed copied-database, device, low-storage/interruption, privacy, hosted, or rollback gates below.

## Overlap and disposition

Android PR #1548 at `8523d93c0f05376b30113a2b24c1f7bbccc30aa0` has zero overlap and remains separate.

RC-0003 conflicts semantically with RC-0002 only because both isolated roots declare different version-33 schemas. Review this preservation/privacy root before choosing RC-0002's final migration number. The composed verification head is evidence only, never a multi-root PR.

## Migration, recovery, and rollback

- Still-v26 installs retain exact rows through atomic table renames.
- v27-through-v32 installs get empty managed recovery tables; data already deleted by historical releases cannot be reconstructed.
- Recovery must operate on a database copy, inventory/hash raw rows, retain the archive, and use a separately reviewed semantic mapper. Never guess a block/PDF mapping or mutate the only copy.
- Logout/account deletion intentionally clears current and quarantined private input together.
- There is no safe in-place downgrade. Rollback is a forward fix; an emergency binary rollback requires a verified matching pre-upgrade database snapshot. Reverting this root restores a confirmed destructive path.

## Security, privacy, and content rights

Recovery rows may contain private notes and annotations. They must not appear in public artifacts, telemetry, or implicit uploads. This root adds no content, translation, lesson, PDF/video asset, Bible/EGW material, credential, signing, or deployment change.

## Dependency order and draft blockers

This schema/privacy root precedes RC-0002. Keep the PR draft until maintainers identify the actual shipped database lineage, production-signed upgrades pass on copied representative v26 databases under low-storage/interruption/process-death conditions, logout/account-deletion privacy is verified on-device, support approves treatment for already-affected users, and required hosted checks pass.

