### PR TITLE
fix(pdf): journal annotation changes durably

### DIFF
--- a/common/auth/src/main/kotlin/app/ss/auth/AuthRepository.kt
+++ b/common/auth/src/main/kotlin/app/ss/auth/AuthRepository.kt
@@ -81,7 +81,8 @@ internal class AuthRepositoryImpl @Inject constructor(
     private val userDao: UserDao,
     private val userInputDao: UserInputDao,
     private val dispatcherProvider: DispatcherProvider,
-    private val connectivityHelper: ConnectivityHelper
+    private val connectivityHelper: ConnectivityHelper,
+    private val privateUserDataCleaners: Set<@JvmSuppressWildcards PrivateUserDataCleaner>,
 ) : AuthRepository {
 
     override suspend fun getUser(): Result<SSUser?> = withContext(dispatcherProvider.io) {
@@ -120,6 +121,10 @@ internal class AuthRepositoryImpl @Inject constructor(
     override suspend fun logout() = withContext(dispatcherProvider.io) {
         userDao.clear()
         userInputDao.clear()
+        privateUserDataCleaners.forEach { cleaner ->
+            runCatching(cleaner::clearPrivateUserData)
+                .onFailure { Timber.e(it, "Failed to clear private user data") }
+        }
     }
 
     override suspend fun deleteAccount() {

--- a/common/auth/src/main/kotlin/app/ss/auth/PrivateUserDataCleaner.kt
+++ b/common/auth/src/main/kotlin/app/ss/auth/PrivateUserDataCleaner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. Adventech <info@adventech.io>
+ * Copyright (c) 2026. Adventech <info@adventech.io>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,35 +20,21 @@
  * THE SOFTWARE.
  */
 
-package app.ss.pdf.di
+package app.ss.auth
 
-import app.ss.auth.PrivateUserDataCleaner
-import app.ss.pdf.FilePdfAnnotationJournal
-import app.ss.pdf.PdfAnnotationJournal
-import app.ss.pdf.PdfReaderImpl
-import app.ss.pdf.PdfReaderPrefs
-import app.ss.pdf.PdfReaderPrefsImpl
-import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.IntoSet
-import ss.libraries.pdf.api.PdfReader
+import dagger.multibindings.Multibinds
+
+/** Clears app-private durable state that is scoped to the signed-in user. */
+fun interface PrivateUserDataCleaner {
+    fun clearPrivateUserData()
+}
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class BindingsModule {
-
-    @Binds
-    internal abstract fun bindReaderPrefs(impl: PdfReaderPrefsImpl): PdfReaderPrefs
-
-    @Binds
-    internal abstract fun bindReader(impl: PdfReaderImpl): PdfReader
-
-    @Binds
-    internal abstract fun bindAnnotationJournal(impl: FilePdfAnnotationJournal): PdfAnnotationJournal
-
-    @Binds
-    @IntoSet
-    internal abstract fun bindPrivateUserDataCleaner(impl: FilePdfAnnotationJournal): PrivateUserDataCleaner
+internal abstract class PrivateUserDataCleanerModule {
+    @Multibinds
+    abstract fun privateUserDataCleaners(): Set<PrivateUserDataCleaner>
 }

--- a/common/auth/src/test/kotlin/app/ss/auth/AuthRepositoryTest.kt
+++ b/common/auth/src/test/kotlin/app/ss/auth/AuthRepositoryTest.kt
@@ -49,6 +49,8 @@ class AuthRepositoryTest {
     private val fakeUserDao = FakeUserDao()
     private val fakeUserInputDao = FakeUserInputDao()
     private val fakeConnectivityHelper = FakeConnectivityHelper(true)
+    private var privateUserDataCleared = false
+    private val privateUserDataCleaner = PrivateUserDataCleaner { privateUserDataCleared = true }
 
     private val fakeUser = UserEntity(
         uid = "uid",
@@ -68,6 +70,7 @@ class AuthRepositoryTest {
         userInputDao = fakeUserInputDao,
         dispatcherProvider = TestDispatcherProvider(),
         connectivityHelper = fakeConnectivityHelper,
+        privateUserDataCleaners = setOf(privateUserDataCleaner),
     )
 
     @Test
@@ -129,6 +132,13 @@ class AuthRepositoryTest {
         repository.logout()
 
         fakeUserInputDao.items shouldNotContain userInput
+    }
+
+    @Test
+    fun `logout - should clear private user data journals`() = runTest {
+        repository.logout()
+
+        privateUserDataCleared shouldBe true
     }
 
 }

--- a/features/pdf/build.gradle.kts
+++ b/features/pdf/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
         exclude(group = "androidx.compose.runtime", module = "runtime") // imported as aar and breaks the build
     }
     implementation(libs.timber)
+    implementation(projects.common.auth)
     implementation(projects.common.core)
     implementation(projects.common.design)
     implementation(projects.common.designCompose)
@@ -81,6 +82,8 @@ dependencies {
     implementation(projects.libraries.media.resources)
     implementation(projects.libraries.pdf.api)
     implementation(projects.services.resources.api)
+
+    testImplementation(libs.bundles.testing.common)
 
     ksp(libs.circuit.codegen)
     ksp(libs.google.hilt.compiler)

--- a/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationJournal.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationJournal.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import android.content.Context
+import app.ss.auth.PrivateUserDataCleaner
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal data class PdfAnnotationKey(
+    val documentId: String,
+    val pdfId: String,
+)
+
+internal sealed interface PdfAnnotationJournalRead {
+    data object Missing : PdfAnnotationJournalRead
+    data object Corrupt : PdfAnnotationJournalRead
+
+    data class Snapshot(
+        val annotations: List<PDFAuxAnnotations>,
+        val dirty: Boolean,
+        val recoveredFromBackup: Boolean,
+    ) : PdfAnnotationJournalRead
+}
+
+internal interface PdfAnnotationJournal {
+    fun read(key: PdfAnnotationKey): PdfAnnotationJournalRead
+
+    /**
+     * Writes and fsyncs a complete, versioned snapshot before promoting it.
+     * Returns false while retaining the previous known-good generation when a write fails.
+     */
+    fun write(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+        dirty: Boolean,
+    ): Boolean
+
+    fun clear()
+}
+
+@Singleton
+internal class FilePdfAnnotationJournal internal constructor(
+    private val rootDirectory: File,
+    private val beforePromote: () -> Unit = {},
+) : PdfAnnotationJournal, PrivateUserDataCleaner {
+
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) : this(File(context.noBackupFilesDir, DIRECTORY_NAME))
+
+    @Synchronized
+    override fun read(key: PdfAnnotationKey): PdfAnnotationJournalRead {
+        val primary = primaryFile(key)
+        decodeFile(primary)?.let { snapshot ->
+            return snapshot.copy(recoveredFromBackup = false)
+        }
+
+        val backup = backupFile(key)
+        decodeFile(backup)?.let { snapshot ->
+            return snapshot.copy(recoveredFromBackup = true)
+        }
+
+        return if (primary.exists() || backup.exists()) {
+            PdfAnnotationJournalRead.Corrupt
+        } else {
+            PdfAnnotationJournalRead.Missing
+        }
+    }
+
+    @Synchronized
+    override fun write(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+        dirty: Boolean,
+    ): Boolean {
+        if (!ensureDirectory()) return false
+
+        val snapshot = PdfAnnotationJournalRead.Snapshot(
+            annotations = annotations.normalized(),
+            dirty = dirty,
+            recoveredFromBackup = false,
+        )
+        val primary = primaryFile(key)
+        val backup = backupFile(key)
+        val temporary = temporaryFile(key)
+
+        return try {
+            writeSynced(temporary, PdfAnnotationJournalCodec.encode(snapshot))
+            if (decodeFile(temporary)?.copy(recoveredFromBackup = false) != snapshot) {
+                return false
+            }
+
+            if (primary.exists()) {
+                if (decodeFile(primary) != null) {
+                    if (backup.exists() && !backup.delete()) return false
+                    if (!primary.renameTo(backup)) return false
+                } else if (!quarantine(primary)) {
+                    return false
+                }
+            }
+
+            beforePromote()
+            temporary.renameTo(primary)
+        } catch (_: IOException) {
+            false
+        } catch (_: IllegalArgumentException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+    }
+
+    @Synchronized
+    override fun clear() {
+        if (!rootDirectory.exists()) return
+        rootDirectory.listFiles().orEmpty().forEach { file ->
+            if (file.isFile) file.delete()
+        }
+        rootDirectory.delete()
+    }
+
+    override fun clearPrivateUserData() = clear()
+
+    internal fun primaryFile(key: PdfAnnotationKey): File =
+        File(rootDirectory, "${key.fileName()}.journal")
+
+    private fun backupFile(key: PdfAnnotationKey): File =
+        File(rootDirectory, "${key.fileName()}.backup")
+
+    private fun temporaryFile(key: PdfAnnotationKey): File =
+        File(rootDirectory, "${key.fileName()}.temporary")
+
+    private fun ensureDirectory(): Boolean = when {
+        rootDirectory.isDirectory -> true
+        rootDirectory.exists() -> false
+        else -> rootDirectory.mkdirs()
+    }
+
+    private fun quarantine(file: File): Boolean {
+        val quarantine = File(rootDirectory, "${file.name}.corrupt-${System.currentTimeMillis()}")
+        return file.renameTo(quarantine)
+    }
+
+    private fun decodeFile(file: File): PdfAnnotationJournalRead.Snapshot? {
+        if (!file.isFile || file.length() !in 1..MAX_FILE_BYTES) return null
+        return try {
+            PdfAnnotationJournalCodec.decode(file.readBytes())
+        } catch (_: IOException) {
+            null
+        } catch (_: SecurityException) {
+            null
+        }
+    }
+
+    private fun writeSynced(file: File, bytes: ByteArray) {
+        FileOutputStream(file, false).use { stream ->
+            stream.write(bytes)
+            stream.flush()
+            stream.fd.sync()
+        }
+    }
+
+    private fun PdfAnnotationKey.fileName(): String {
+        val input = "$documentId\u0000$pdfId".toByteArray(Charsets.UTF_8)
+        return MessageDigest.getInstance(SHA_256)
+            .digest(input)
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+
+    private companion object {
+        const val DIRECTORY_NAME = "pdf-annotation-journal-v1"
+        const val SHA_256 = "SHA-256"
+        const val MAX_FILE_BYTES = 32L * 1024L * 1024L
+    }
+}
+
+private object PdfAnnotationJournalCodec {
+    private const val MAGIC = 0x53535041
+    private const val VERSION = 1
+    private const val CHECKSUM_BYTES = 32
+    private const val MAX_PAGES = 100_000
+    private const val MAX_ANNOTATIONS = 1_000_000
+    private const val MAX_JSON_BYTES = 4 * 1024 * 1024
+    private const val MAX_ENCODED_BYTES = 32 * 1024 * 1024
+
+    fun encode(snapshot: PdfAnnotationJournalRead.Snapshot): ByteArray {
+        require(snapshot.annotations.size <= MAX_PAGES)
+        var annotationCount = 0
+        val payload = ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(MAGIC)
+                output.writeInt(VERSION)
+                output.writeBoolean(snapshot.dirty)
+                output.writeInt(snapshot.annotations.size)
+                snapshot.annotations.forEach { page ->
+                    require(page.pageIndex >= 0)
+                    annotationCount += page.annotations.size
+                    require(annotationCount <= MAX_ANNOTATIONS)
+                    output.writeInt(page.pageIndex)
+                    output.writeInt(page.annotations.size)
+                    page.annotations.forEach { json ->
+                        val encoded = json.toByteArray(Charsets.UTF_8)
+                        require(encoded.size <= MAX_JSON_BYTES)
+                        require(bytes.size() + encoded.size + Int.SIZE_BYTES + CHECKSUM_BYTES <= MAX_ENCODED_BYTES)
+                        output.writeInt(encoded.size)
+                        output.write(encoded)
+                    }
+                }
+            }
+            bytes.toByteArray()
+        }
+        require(payload.size + CHECKSUM_BYTES <= MAX_ENCODED_BYTES)
+        val checksum = MessageDigest.getInstance("SHA-256").digest(payload)
+        return payload + checksum
+    }
+
+    fun decode(bytes: ByteArray): PdfAnnotationJournalRead.Snapshot? {
+        if (bytes.size <= CHECKSUM_BYTES) return null
+        val payload = bytes.copyOfRange(0, bytes.size - CHECKSUM_BYTES)
+        val actualChecksum = bytes.copyOfRange(bytes.size - CHECKSUM_BYTES, bytes.size)
+        val expectedChecksum = MessageDigest.getInstance("SHA-256").digest(payload)
+        if (!MessageDigest.isEqual(actualChecksum, expectedChecksum)) return null
+
+        return try {
+            DataInputStream(ByteArrayInputStream(payload)).use { input ->
+                if (input.readInt() != MAGIC || input.readInt() != VERSION) return null
+                val dirty = input.readBoolean()
+                val pageCount = input.readInt()
+                if (pageCount !in 0..MAX_PAGES) return null
+
+                var annotationCount = 0
+                val pages = buildList(pageCount) {
+                    repeat(pageCount) {
+                        val pageIndex = input.readInt()
+                        val pageAnnotationCount = input.readInt()
+                        if (pageIndex < 0 || pageAnnotationCount !in 0..MAX_ANNOTATIONS) return null
+                        annotationCount += pageAnnotationCount
+                        if (annotationCount > MAX_ANNOTATIONS) return null
+                        val annotations = buildList(pageAnnotationCount) {
+                            repeat(pageAnnotationCount) {
+                                val length = input.readInt()
+                                if (length !in 0..MAX_JSON_BYTES || length > input.available()) return null
+                                val encoded = ByteArray(length)
+                                input.readFully(encoded)
+                                add(encoded.toString(Charsets.UTF_8))
+                            }
+                        }
+                        add(PDFAuxAnnotations(pageIndex, annotations))
+                    }
+                }
+                if (input.available() != 0) return null
+                PdfAnnotationJournalRead.Snapshot(
+                    annotations = pages.normalized(),
+                    dirty = dirty,
+                    recoveredFromBackup = false,
+                )
+            }
+        } catch (_: IOException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+}
+
+internal fun List<PDFAuxAnnotations>.normalized(): List<PDFAuxAnnotations> =
+    groupBy { it.pageIndex }
+        .toSortedMap()
+        .map { (pageIndex, pages) ->
+            PDFAuxAnnotations(pageIndex, pages.flatMap { it.annotations })
+        }

--- a/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationSaveQueue.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationSaveQueue.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class PdfAnnotationSaveQueue(
+    private val scope: CoroutineScope,
+    private val delayMillis: Long = DEFAULT_DELAY_MILLIS,
+    private val save: (Pair<PdfAnnotationKey, List<PDFAuxAnnotations>>) -> Unit,
+) {
+    private val jobs = mutableMapOf<PdfAnnotationKey, Job>()
+
+    fun enqueue(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+    ) {
+        jobs.remove(key)?.cancel()
+        val snapshot = annotations.normalized()
+        jobs[key] = scope.launch {
+            delay(delayMillis)
+            save(key to snapshot)
+        }
+    }
+
+    fun flush(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+    ) {
+        jobs.remove(key)?.cancel()
+        save(key to annotations.normalized())
+    }
+
+    private companion object {
+        const val DEFAULT_DELAY_MILLIS = 350L
+    }
+}

--- a/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationSession.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/PdfAnnotationSession.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+
+internal enum class PdfAnnotationRestoreSource {
+    REMOTE,
+    IN_MEMORY_DIRTY,
+    JOURNAL_DIRTY,
+}
+
+internal data class PdfAnnotationRestorePlan(
+    val annotations: List<PDFAuxAnnotations>,
+    val fallback: List<PDFAuxAnnotations>?,
+    val source: PdfAnnotationRestoreSource,
+    val replayRequired: Boolean,
+)
+
+internal class PdfAnnotationSession(
+    private val journal: PdfAnnotationJournal,
+) {
+    private val inMemoryDirty = mutableMapOf<PdfAnnotationKey, List<PDFAuxAnnotations>>()
+
+    @Synchronized
+    fun record(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+    ): Boolean {
+        val normalized = annotations.normalized()
+        inMemoryDirty[key] = normalized
+        return journal.write(key, normalized, dirty = true)
+    }
+
+    @Synchronized
+    fun resolve(
+        key: PdfAnnotationKey,
+        remoteAnnotations: List<PDFAuxAnnotations>,
+    ): PdfAnnotationRestorePlan {
+        val remote = remoteAnnotations.normalized()
+        inMemoryDirty[key]?.let { local ->
+            if (local == remote && journal.write(key, local, dirty = false)) {
+                inMemoryDirty.remove(key)
+                return PdfAnnotationRestorePlan(
+                    annotations = remote,
+                    fallback = local,
+                    source = PdfAnnotationRestoreSource.REMOTE,
+                    replayRequired = false,
+                )
+            }
+            return PdfAnnotationRestorePlan(
+                annotations = local,
+                fallback = remote,
+                source = PdfAnnotationRestoreSource.IN_MEMORY_DIRTY,
+                replayRequired = false,
+            )
+        }
+
+        return when (val stored = journal.read(key)) {
+            PdfAnnotationJournalRead.Missing,
+            PdfAnnotationJournalRead.Corrupt,
+            -> PdfAnnotationRestorePlan(
+                annotations = remote,
+                fallback = null,
+                source = PdfAnnotationRestoreSource.REMOTE,
+                replayRequired = false,
+            )
+
+            is PdfAnnotationJournalRead.Snapshot -> {
+                val local = stored.annotations.normalized()
+                if (!stored.dirty || local == remote) {
+                    if (stored.dirty) journal.write(key, local, dirty = false)
+                    PdfAnnotationRestorePlan(
+                        annotations = remote,
+                        fallback = local,
+                        source = PdfAnnotationRestoreSource.REMOTE,
+                        replayRequired = false,
+                    )
+                } else {
+                    inMemoryDirty[key] = local
+                    PdfAnnotationRestorePlan(
+                        annotations = local,
+                        fallback = remote,
+                        source = PdfAnnotationRestoreSource.JOURNAL_DIRTY,
+                        replayRequired = true,
+                    )
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    fun resolveAbsent(key: PdfAnnotationKey): PdfAnnotationRestorePlan? {
+        inMemoryDirty[key]?.let { local ->
+            return PdfAnnotationRestorePlan(
+                annotations = local,
+                fallback = null,
+                source = PdfAnnotationRestoreSource.IN_MEMORY_DIRTY,
+                replayRequired = false,
+            )
+        }
+
+        val stored = journal.read(key) as? PdfAnnotationJournalRead.Snapshot ?: return null
+        if (!stored.dirty) return null
+
+        val local = stored.annotations.normalized()
+        inMemoryDirty[key] = local
+        return PdfAnnotationRestorePlan(
+            annotations = local,
+            fallback = null,
+            source = PdfAnnotationRestoreSource.JOURNAL_DIRTY,
+            replayRequired = true,
+        )
+    }
+}

--- a/features/pdf/src/main/kotlin/app/ss/pdf/ui/ReadPdfViewModel.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/ui/ReadPdfViewModel.kt
@@ -25,6 +25,12 @@ package app.ss.pdf.ui
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.ss.pdf.PdfAnnotationJournal
+import app.ss.pdf.PdfAnnotationKey
+import app.ss.pdf.PdfAnnotationRestorePlan
+import app.ss.pdf.PdfAnnotationSaveQueue
+import app.ss.pdf.PdfAnnotationSession
+import app.ss.pdf.normalized
 import app.ss.models.media.MediaAvailability
 import com.pspdfkit.annotations.Annotation
 import com.pspdfkit.document.PdfDocument
@@ -52,11 +58,17 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class ReadPdfViewModel @Inject constructor(
+internal class ReadPdfViewModel @Inject constructor(
     private val pdfReader: PdfReader,
     private val resourcesRepository: ResourcesRepository,
+    annotationJournal: PdfAnnotationJournal,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    private val annotationSession = PdfAnnotationSession(annotationJournal)
+    private val annotationSaveQueue = PdfAnnotationSaveQueue(viewModelScope) { (key, annotations) ->
+        saveRequest(key.documentId, key.pdfId, annotations)
+    }
 
     private val _pdfFiles = MutableStateFlow<List<LocalFile>>(emptyList())
     val pdfsFilesFlow: StateFlow<List<LocalFile>> = _pdfFiles.asStateFlow()
@@ -82,10 +94,8 @@ class ReadPdfViewModel @Inject constructor(
                     .toList()
             }
             .map { input ->
-                val pdfs = savedStateHandle.screen?.pdfs.orEmpty()
-                pdfs.mapIndexed { index, pdf ->
-                    index to input.filter { it.pdfId == pdf.id }.flatMap { it.data }
-                }.toMap()
+                val pdfIds = savedStateHandle.screen?.pdfs.orEmpty().map { it.id }
+                mapAnnotationsByPdfId(pdfIds, input)
             }
             .catch { Timber.e(it) }
             .stateIn(viewModelScope, emptyMap<Int, List<PDFAuxAnnotations>>())
@@ -114,31 +124,101 @@ class ReadPdfViewModel @Inject constructor(
     }
 
     fun saveAnnotations(document: PdfDocument, docIndex: Int) {
-        val pdfs = savedStateHandle.screen?.pdfs ?: return
-        val documentId = savedStateHandle.screen?.documentId ?: return
-        val pdfId = pdfs.getOrNull(docIndex)?.id ?: return
-
-        val syncAnnotations = document.annotations().toSync()
-
-        val userInput = UserInputRequest.Annotation(
-            blockId = pdfId,
-            pdfId = pdfId,
-            data = syncAnnotations
-        )
-
-       resourcesRepository.saveDocumentInput(documentId, userInput)
+        captureAnnotations(document, docIndex, flush = false)
     }
 
-    private fun List<Annotation>.toSync(): List<PDFAuxAnnotations> {
-        val groupedAnnotations = groupBy { it.pageIndex }
-        return groupedAnnotations.keys.mapNotNull { pageIndex ->
-            val list = groupedAnnotations[pageIndex] ?: return@mapNotNull null
-            val annotations = list.map { it.toInstantJson() }.filter(::invalidInstantJson)
-            PDFAuxAnnotations(pageIndex, annotations)
+    fun flushAnnotations(document: PdfDocument, docIndex: Int) {
+        captureAnnotations(document, docIndex, flush = true)
+    }
+
+    private fun captureAnnotations(
+        document: PdfDocument,
+        docIndex: Int,
+        flush: Boolean,
+    ) {
+        val annotations = try {
+            document.annotations().toSync()
+        } catch (error: RuntimeException) {
+            Timber.e(error, "Unable to serialize a complete PDF annotation snapshot")
+            return
+        }
+        saveAnnotations(annotations, docIndex, flush)
+    }
+
+    fun restorePlan(
+        docIndex: Int,
+        remoteAnnotations: List<PDFAuxAnnotations>?,
+    ): PdfAnnotationRestorePlan? {
+        val pdfs = savedStateHandle.screen?.pdfs ?: return null
+        val documentId = savedStateHandle.screen?.documentId ?: return null
+        val pdfId = pdfs.getOrNull(docIndex)?.id ?: return null
+        val key = PdfAnnotationKey(documentId, pdfId)
+        val plan = if (remoteAnnotations == null) {
+            annotationSession.resolveAbsent(key)
+        } else {
+            annotationSession.resolve(key, remoteAnnotations)
+        }
+        return plan?.also {
+            if (plan.replayRequired) annotationSaveQueue.flush(key, plan.annotations)
         }
     }
 
-    private fun invalidInstantJson(json: String) = json != "null"
+    private fun saveAnnotations(
+        annotations: List<PDFAuxAnnotations>,
+        docIndex: Int,
+        flush: Boolean,
+    ) {
+        val pdfs = savedStateHandle.screen?.pdfs ?: return
+        val documentId = savedStateHandle.screen?.documentId ?: return
+        val pdfId = pdfs.getOrNull(docIndex)?.id ?: return
+        val key = PdfAnnotationKey(documentId, pdfId)
+
+        if (!annotationSession.record(key, annotations)) {
+            Timber.e("Unable to durably journal PDF annotations")
+        }
+        if (flush) {
+            annotationSaveQueue.flush(key, annotations)
+        } else {
+            annotationSaveQueue.enqueue(key, annotations)
+        }
+    }
+
+    private fun saveRequest(
+        documentId: String,
+        pdfId: String,
+        annotations: List<PDFAuxAnnotations>,
+    ) {
+        val userInput = UserInputRequest.Annotation(
+            blockId = pdfId,
+            pdfId = pdfId,
+            data = annotations.normalized(),
+        )
+
+        resourcesRepository.saveDocumentInput(documentId, userInput)
+    }
+}
+
+internal fun mapAnnotationsByPdfId(
+    pdfIds: List<String>,
+    inputs: List<UserInput.Annotation>,
+): Map<Int, List<PDFAuxAnnotations>> {
+    val inputsByPdfId = inputs.groupBy { it.pdfId }
+    return pdfIds.mapIndexedNotNull { index, pdfId ->
+        inputsByPdfId[pdfId]?.let { matches -> index to matches.flatMap { it.data } }
+    }.toMap()
+}
+
+internal fun List<Annotation>.toSync(): List<PDFAuxAnnotations> {
+    val groupedAnnotations = groupBy { it.pageIndex }
+    return groupedAnnotations.keys.mapNotNull { pageIndex ->
+        val list = groupedAnnotations[pageIndex] ?: return@mapNotNull null
+        val annotations = list.map { annotation ->
+            annotation.toInstantJson().also { json ->
+                check(json != "null") { "PDF annotation did not serialize" }
+            }
+        }
+        PDFAuxAnnotations(pageIndex, annotations)
+    }.normalized()
 }
 
 fun PdfDocument.annotations(): List<Annotation> {

--- a/features/pdf/src/main/kotlin/app/ss/pdf/ui/SSReadPdfActivity.kt
+++ b/features/pdf/src/main/kotlin/app/ss/pdf/ui/SSReadPdfActivity.kt
@@ -35,7 +35,11 @@ import app.ss.media.playback.ui.nowPlaying.showNowPlaying
 import app.ss.media.playback.ui.video.showVideoList
 import app.ss.pdf.PdfReaderPrefs
 import app.ss.pdf.R
+import app.ss.pdf.PdfAnnotationRestorePlan
+import app.ss.pdf.normalized
 import com.cryart.sabbathschool.core.extensions.view.tint
+import com.pspdfkit.annotations.Annotation
+import com.pspdfkit.annotations.AnnotationProvider
 import com.pspdfkit.document.DocumentSource
 import com.pspdfkit.document.PdfDocument
 import com.pspdfkit.ui.DocumentDescriptor
@@ -44,6 +48,8 @@ import com.pspdfkit.ui.tabs.PdfTabBarCloseMode
 import dagger.hilt.android.AndroidEntryPoint
 import io.adventech.blockkit.model.input.PDFAuxAnnotations
 import ss.foundation.coroutines.flow.collectIn
+import timber.log.Timber
+import java.util.IdentityHashMap
 import javax.inject.Inject
 import app.ss.translations.R as L10n
 import ss.libraries.media.resources.R as MediaR
@@ -57,6 +63,8 @@ class SSReadPdfActivity : PdfActivity() {
     private val viewModel by viewModels<ReadPdfViewModel>()
 
     private var loadedDocuments: List<DocumentDescriptor> = emptyList()
+    private val annotationListeners = IdentityHashMap<PdfDocument, AnnotationProvider.OnAnnotationUpdatedListener>()
+    private val restoringDocuments = java.util.Collections.newSetFromMap(IdentityHashMap<PdfDocument, Boolean>())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -140,7 +148,9 @@ class SSReadPdfActivity : PdfActivity() {
         viewModel.annotationsStateFlow.collectIn(this) { annotations ->
             annotations.forEach { (index, annotations) ->
                 val document = documentCoordinator.documents.getOrNull(index)?.document ?: return@forEach
-                loadAnnotations(document, annotations)
+                viewModel.restorePlan(index, annotations)?.let { plan ->
+                    loadAnnotations(document, plan)
+                }
             }
         }
 
@@ -148,34 +158,78 @@ class SSReadPdfActivity : PdfActivity() {
     }
 
     override fun onDocumentLoaded(document: PdfDocument) {
-        val index = loadedDocuments.indexOfFirst { it.uid == documentCoordinator.visibleDocument?.uid }
+        val index = loadedDocuments.indexOfFirst { descriptor ->
+            descriptor.document === document || descriptor.uid == document.uid
+        }
         if (index >= 0) {
-            viewModel.annotationsStateFlow.value[index]?.let { annotations ->
-                loadAnnotations(document, annotations)
+            registerAnnotationListener(document, index)
+            val annotations = viewModel.annotationsStateFlow.value[index]
+            viewModel.restorePlan(index, annotations)?.let { plan ->
+                loadAnnotations(document, plan)
             }
         }
     }
 
-    private fun loadAnnotations(document: PdfDocument, annotations: List<PDFAuxAnnotations>) {
-        if (annotations.isEmpty()) return
+    private fun registerAnnotationListener(document: PdfDocument, index: Int) {
+        if (annotationListeners.containsKey(document)) return
+        val listener = object : AnnotationProvider.OnAnnotationUpdatedListener {
+            override fun onAnnotationCreated(annotation: Annotation) = annotationsChanged(document, index)
+            override fun onAnnotationUpdated(annotation: Annotation) = annotationsChanged(document, index)
+            override fun onAnnotationRemoved(annotation: Annotation) = annotationsChanged(document, index)
 
-        with(document.annotationProvider) {
-            document.annotations()
-                .forEach { removeAnnotationFromPage(it) }
-
-            annotations
-                .flatMap { it.annotations }
-                .forEach { createAnnotationFromInstantJson(it) }
+            override fun onAnnotationZOrderChanged(
+                pageIndex: Int,
+                oldOrder: List<Annotation>,
+                newOrder: List<Annotation>,
+            ) = annotationsChanged(document, index)
         }
+        document.annotationProvider.addOnAnnotationUpdatedListener(listener)
+        annotationListeners[document] = listener
+    }
+
+    private fun annotationsChanged(document: PdfDocument, index: Int) {
+        if (document in restoringDocuments) return
+        viewModel.saveAnnotations(document, index)
+    }
+
+    private fun loadAnnotations(document: PdfDocument, plan: PdfAnnotationRestorePlan) {
+        restoringDocuments += document
+        val restored = try {
+            replaceAnnotationsSafely(
+                current = { document.annotations().toSync() },
+                clear = {
+                    document.annotations().forEach(document.annotationProvider::removeAnnotationFromPage)
+                },
+                apply = { annotations ->
+                    annotations
+                        .flatMap { it.annotations }
+                        .forEach { json ->
+                            checkNotNull(document.annotationProvider.createAnnotationFromInstantJson(json))
+                        }
+                },
+                candidate = plan.annotations,
+                fallback = plan.fallback,
+            )
+        } finally {
+            restoringDocuments -= document
+        }
+        if (!restored) Timber.e("Rejected malformed PDF annotation payload and restored known-good state")
     }
 
     override fun onStop() {
-        val documents = loadedDocuments.mapNotNull { it.document }
-        documents.forEachIndexed { index, pdfDocument ->
-            viewModel.saveAnnotations(pdfDocument, index)
+        loadedDocuments.map { it.document }.forEachIndexedPresent { index, pdfDocument ->
+            viewModel.flushAnnotations(pdfDocument, index)
         }
         readerPrefs.saveConfiguration(configuration.configuration)
         super.onStop()
+    }
+
+    override fun onDestroy() {
+        annotationListeners.forEach { (document, listener) ->
+            document.annotationProvider.removeOnAnnotationUpdatedListener(listener)
+        }
+        annotationListeners.clear()
+        super.onDestroy()
     }
 
     companion object {
@@ -185,3 +239,44 @@ class SSReadPdfActivity : PdfActivity() {
 }
 
 internal const val ARG_PDF_SCREEN = "as_arg_pdf_screen"
+
+internal fun <T : Any> List<T?>.forEachIndexedPresent(action: (Int, T) -> Unit) {
+    forEachIndexed { index, value ->
+        if (value != null) action(index, value)
+    }
+}
+
+internal fun replaceAnnotationsSafely(
+    current: () -> List<PDFAuxAnnotations>,
+    clear: () -> Unit,
+    apply: (List<PDFAuxAnnotations>) -> Unit,
+    candidate: List<PDFAuxAnnotations>,
+    fallback: List<PDFAuxAnnotations>?,
+): Boolean {
+    val before = try {
+        current().normalized()
+    } catch (_: Exception) {
+        return false
+    }
+    val replacement = candidate.normalized()
+    if (before == replacement) return true
+
+    return try {
+        clear()
+        apply(replacement)
+        true
+    } catch (_: Exception) {
+        val preferredRecovery = fallback?.normalized() ?: before
+        val recovered = runCatching {
+            clear()
+            apply(preferredRecovery)
+        }.isSuccess
+        if (!recovered && preferredRecovery != before) {
+            runCatching {
+                clear()
+                apply(before)
+            }
+        }
+        false
+    }
+}

--- a/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationJournalTest.kt
+++ b/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationJournalTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import org.amshove.kluent.shouldBe
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.IOException
+
+class PdfAnnotationJournalTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val key = PdfAnnotationKey(documentId = "document", pdfId = "pdf")
+    private val first = listOf(PDFAuxAnnotations(0, listOf("{\"uuid\":\"first\"}")))
+    private val second = listOf(PDFAuxAnnotations(1, listOf("{\"uuid\":\"second\"}")))
+
+    @Test
+    fun `dirty snapshot survives a new journal instance`() {
+        val directory = temporaryFolder.newFolder()
+        val firstProcess = FilePdfAnnotationJournal(directory)
+
+        firstProcess.write(key, first, dirty = true) shouldBe true
+
+        val afterProcessDeath = FilePdfAnnotationJournal(directory).read(key)
+        assertEquals(
+            PdfAnnotationJournalRead.Snapshot(
+                annotations = first,
+                dirty = true,
+                recoveredFromBackup = false,
+            ),
+            afterProcessDeath,
+        )
+    }
+
+    @Test
+    fun `interrupted promotion preserves the previous known-good generation`() {
+        val directory = temporaryFolder.newFolder()
+        FilePdfAnnotationJournal(directory).write(key, first, dirty = true) shouldBe true
+        val interrupted = FilePdfAnnotationJournal(
+            rootDirectory = directory,
+            beforePromote = { throw IOException("synthetic promotion failure") },
+        )
+
+        interrupted.write(key, second, dirty = true) shouldBe false
+
+        assertEquals(
+            PdfAnnotationJournalRead.Snapshot(
+                annotations = first,
+                dirty = true,
+                recoveredFromBackup = true,
+            ),
+            FilePdfAnnotationJournal(directory).read(key),
+        )
+    }
+
+    @Test
+    fun `corrupt primary falls back to previous generation without deleting evidence`() {
+        val directory = temporaryFolder.newFolder()
+        val journal = FilePdfAnnotationJournal(directory)
+        journal.write(key, first, dirty = true) shouldBe true
+        journal.write(key, second, dirty = true) shouldBe true
+        val primary = journal.primaryFile(key)
+        primary.writeBytes(byteArrayOf(1, 2, 3))
+
+        assertEquals(
+            PdfAnnotationJournalRead.Snapshot(
+                annotations = first,
+                dirty = true,
+                recoveredFromBackup = true,
+            ),
+            journal.read(key),
+        )
+        primary.exists() shouldBe true
+    }
+
+    @Test
+    fun `corrupt only generation is reported and retained`() {
+        val directory = temporaryFolder.newFolder()
+        val journal = FilePdfAnnotationJournal(directory)
+        journal.write(key, first, dirty = true) shouldBe true
+        val primary = journal.primaryFile(key)
+        primary.writeBytes(byteArrayOf(1, 2, 3))
+
+        journal.read(key) shouldBe PdfAnnotationJournalRead.Corrupt
+        primary.exists() shouldBe true
+    }
+
+    @Test
+    fun `private journal generations are removed on user-data clear`() {
+        val directory = temporaryFolder.newFolder()
+        val journal = FilePdfAnnotationJournal(directory)
+        journal.write(key, first, dirty = true) shouldBe true
+        journal.write(key, second, dirty = false) shouldBe true
+
+        journal.clearPrivateUserData()
+
+        journal.read(key) shouldBe PdfAnnotationJournalRead.Missing
+        directory.exists() shouldBe false
+    }
+}

--- a/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationSaveQueueTest.kt
+++ b/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationSaveQueueTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PdfAnnotationSaveQueueTest {
+
+    private val firstKey = PdfAnnotationKey("document", "first-pdf")
+    private val secondKey = PdfAnnotationKey("document", "second-pdf")
+    private val first = listOf(PDFAuxAnnotations(0, listOf("first")))
+    private val second = listOf(PDFAuxAnnotations(0, listOf("second")))
+
+    @Test
+    fun `debounce is isolated per PDF`() = runTest {
+        val saves = mutableListOf<Pair<PdfAnnotationKey, List<PDFAuxAnnotations>>>()
+        val queue = PdfAnnotationSaveQueue(this, delayMillis = 100, save = saves::add)
+
+        queue.enqueue(firstKey, first)
+        queue.enqueue(secondKey, second)
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(listOf(firstKey to first, secondKey to second), saves)
+    }
+
+    @Test
+    fun `rapid updates coalesce to the newest complete snapshot`() = runTest {
+        val saves = mutableListOf<Pair<PdfAnnotationKey, List<PDFAuxAnnotations>>>()
+        val queue = PdfAnnotationSaveQueue(this, delayMillis = 100, save = saves::add)
+
+        queue.enqueue(firstKey, first)
+        queue.enqueue(firstKey, second)
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(listOf(firstKey to second), saves)
+    }
+
+    @Test
+    fun `lifecycle flush persists immediately and cancels pending duplicate`() = runTest {
+        val saves = mutableListOf<Pair<PdfAnnotationKey, List<PDFAuxAnnotations>>>()
+        val queue = PdfAnnotationSaveQueue(this, delayMillis = 100, save = saves::add)
+
+        queue.enqueue(firstKey, first)
+        queue.flush(firstKey, second)
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(listOf(firstKey to second), saves)
+    }
+}

--- a/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationSessionTest.kt
+++ b/features/pdf/src/test/kotlin/app/ss/pdf/PdfAnnotationSessionTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import org.amshove.kluent.shouldBe
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PdfAnnotationSessionTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val key = PdfAnnotationKey(documentId = "document", pdfId = "pdf")
+    private val stale = listOf(PDFAuxAnnotations(0, listOf("{\"uuid\":\"stale\"}")))
+    private val local = listOf(PDFAuxAnnotations(0, listOf("{\"uuid\":\"local\"}")))
+    private val newerRemote = listOf(PDFAuxAnnotations(0, listOf("{\"uuid\":\"newer\"}")))
+
+    @Test
+    fun `late repository emission cannot overwrite an in-memory dirty snapshot`() {
+        val session = PdfAnnotationSession(FakePdfAnnotationJournal())
+
+        session.record(key, local) shouldBe true
+
+        assertEquals(
+            PdfAnnotationRestorePlan(
+                annotations = local,
+                fallback = stale,
+                source = PdfAnnotationRestoreSource.IN_MEMORY_DIRTY,
+                replayRequired = false,
+            ),
+            session.resolve(key, stale),
+        )
+    }
+
+    @Test
+    fun `process restart restores dirty journal and requests persistence replay`() {
+        val directory = temporaryFolder.newFolder()
+        PdfAnnotationSession(FilePdfAnnotationJournal(directory)).record(key, local) shouldBe true
+
+        val restarted = PdfAnnotationSession(FilePdfAnnotationJournal(directory))
+
+        assertEquals(
+            PdfAnnotationRestorePlan(
+                annotations = local,
+                fallback = stale,
+                source = PdfAnnotationRestoreSource.JOURNAL_DIRTY,
+                replayRequired = true,
+            ),
+            restarted.resolve(key, stale),
+        )
+    }
+
+    @Test
+    fun `process restart restores dirty journal before repository emits`() {
+        val directory = temporaryFolder.newFolder()
+        PdfAnnotationSession(FilePdfAnnotationJournal(directory)).record(key, local) shouldBe true
+
+        val restarted = PdfAnnotationSession(FilePdfAnnotationJournal(directory))
+
+        assertEquals(
+            PdfAnnotationRestorePlan(
+                annotations = local,
+                fallback = null,
+                source = PdfAnnotationRestoreSource.JOURNAL_DIRTY,
+                replayRequired = true,
+            ),
+            restarted.resolveAbsent(key),
+        )
+    }
+
+    @Test
+    fun `matching durable repository snapshot compacts dirty journal without changing wire data`() {
+        val directory = temporaryFolder.newFolder()
+        PdfAnnotationSession(FilePdfAnnotationJournal(directory)).record(key, local) shouldBe true
+        val restarted = PdfAnnotationSession(FilePdfAnnotationJournal(directory))
+
+        assertEquals(local, restarted.resolve(key, local).annotations)
+
+        val afterCompaction = PdfAnnotationSession(FilePdfAnnotationJournal(directory))
+        assertEquals(
+            PdfAnnotationRestorePlan(
+                annotations = newerRemote,
+                fallback = local,
+                source = PdfAnnotationRestoreSource.REMOTE,
+                replayRequired = false,
+            ),
+            afterCompaction.resolve(key, newerRemote),
+        )
+    }
+
+    @Test
+    fun `failed disk write still guards dirty ink for the current process`() {
+        val session = PdfAnnotationSession(FakePdfAnnotationJournal(writeSucceeds = false))
+
+        session.record(key, local) shouldBe false
+
+        assertEquals(local, session.resolve(key, stale).annotations)
+        session.resolve(key, stale).source shouldBe PdfAnnotationRestoreSource.IN_MEMORY_DIRTY
+    }
+}
+
+private class FakePdfAnnotationJournal(
+    private val writeSucceeds: Boolean = true,
+) : PdfAnnotationJournal {
+    private val entries = mutableMapOf<PdfAnnotationKey, PdfAnnotationJournalRead.Snapshot>()
+
+    override fun read(key: PdfAnnotationKey): PdfAnnotationJournalRead =
+        entries[key] ?: PdfAnnotationJournalRead.Missing
+
+    override fun write(
+        key: PdfAnnotationKey,
+        annotations: List<PDFAuxAnnotations>,
+        dirty: Boolean,
+    ): Boolean {
+        if (writeSucceeds) {
+            entries[key] = PdfAnnotationJournalRead.Snapshot(annotations, dirty, false)
+        }
+        return writeSucceeds
+    }
+
+    override fun clear() = entries.clear()
+}

--- a/features/pdf/src/test/kotlin/app/ss/pdf/ui/AnnotationRestoreTest.kt
+++ b/features/pdf/src/test/kotlin/app/ss/pdf/ui/AnnotationRestoreTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package app.ss.pdf.ui
+
+import io.adventech.blockkit.model.input.PDFAuxAnnotations
+import io.adventech.blockkit.model.input.UserInput
+import org.amshove.kluent.shouldBe
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnnotationRestoreTest {
+
+    private val current = listOf(PDFAuxAnnotations(0, listOf("current")))
+    private val candidate = listOf(PDFAuxAnnotations(0, listOf("valid", "corrupt")))
+
+    @Test
+    fun `lifecycle flush preserves descriptor indexes when an earlier PDF is not loaded`() {
+        val flushed = mutableListOf<Pair<Int, String>>()
+
+        listOf("first", null, "third").forEachIndexedPresent { index, document ->
+            flushed += index to document
+        }
+
+        assertEquals(listOf(0 to "first", 2 to "third"), flushed)
+    }
+
+    @Test
+    fun `annotation mapping distinguishes an absent record from an explicit empty snapshot`() {
+        val explicitlyEmpty = UserInput.Annotation(
+            blockId = "second",
+            id = "input",
+            timestamp = 1,
+            pdfId = "second",
+            data = emptyList(),
+        )
+
+        val mapped = mapAnnotationsByPdfId(
+            pdfIds = listOf("first", "second"),
+            inputs = listOf(explicitlyEmpty),
+        )
+
+        mapped.containsKey(0) shouldBe false
+        mapped.containsKey(1) shouldBe true
+        assertEquals(emptyList<PDFAuxAnnotations>(), mapped[1])
+    }
+
+    @Test
+    fun `malformed payload restores the full pre-load snapshot instead of leaving a partial document`() {
+        val provider = FakeAnnotationProvider(current)
+
+        replaceAnnotationsSafely(
+            current = provider::snapshot,
+            clear = provider::clear,
+            apply = provider::apply,
+            candidate = candidate,
+            fallback = null,
+        ) shouldBe false
+
+        assertEquals(current, provider.snapshot())
+    }
+
+    @Test
+    fun `unreadable current snapshot rejects reload before destructive clear`() {
+        var cleared = false
+        var applied = false
+
+        replaceAnnotationsSafely(
+            current = { throw IllegalStateException("synthetic serialization failure") },
+            clear = { cleared = true },
+            apply = { applied = true },
+            candidate = candidate,
+            fallback = null,
+        ) shouldBe false
+
+        cleared shouldBe false
+        applied shouldBe false
+    }
+
+    @Test
+    fun `valid payload replaces the previous snapshot`() {
+        val provider = FakeAnnotationProvider(current)
+        val valid = listOf(PDFAuxAnnotations(1, listOf("replacement")))
+
+        replaceAnnotationsSafely(
+            current = provider::snapshot,
+            clear = provider::clear,
+            apply = provider::apply,
+            candidate = valid,
+            fallback = current,
+        ) shouldBe true
+
+        assertEquals(valid, provider.snapshot())
+    }
+}
+
+private class FakeAnnotationProvider(initial: List<PDFAuxAnnotations>) {
+    private val annotations = initial.flatMap { page ->
+        page.annotations.map { page.pageIndex to it }
+    }.toMutableList()
+
+    fun snapshot(): List<PDFAuxAnnotations> = annotations
+        .groupBy({ it.first }, { it.second })
+        .map { (pageIndex, values) -> PDFAuxAnnotations(pageIndex, values) }
+
+    fun clear() = annotations.clear()
+
+    fun apply(snapshot: List<PDFAuxAnnotations>) {
+        snapshot.forEach { page ->
+            page.annotations.forEach { value ->
+                if (value == "corrupt") throw IllegalArgumentException("synthetic malformed payload")
+                annotations += page.pageIndex to value
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Draft PR packet: ADV-2026-0004

## Proposed PR

- Suggested title: `fix(pdf): journal annotation changes durably`
- Upstream target: `Adventech/sabbath-school-android` / `main`
- Audited and last revalidated public base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Published fork branch: `fix/adv-2026-0004-pdf-annotation-journal`
- Published fork head: `d405036605dd2d45a82d8ae0a796049a09154f8b`
- Shape: one commit, sole parent is the base above; one isolated root only (`RC-0004`)
- State: published as draft PR [#1551](https://github.com/Adventech/sabbath-school-android/pull/1551) from the authorized personal fork; not merged or deployed.

Publication privacy note: the branch commit metadata was recreated with the account's GitHub noreply identity before review. Its source tree, message, parent, and stable patch ID are unchanged, so the recorded source-tree validation remains applicable to the published head.

The canonical worklog proves this is an published, complete head with zero changed-file overlap against RC-0001, RC-0002, and RC-0003, so it qualifies for a separate packet.

## Why

PDF annotation persistence occurred only in `onStop()`, leaving edits vulnerable to process death or native failure. Restore removed current annotations before validating incoming Instant JSON, serialization silently dropped values equal to `null`, absent and explicitly empty states were conflated, and compacted descriptor indexes could save under the wrong PDF ID. This is a confirmed P0 PDF slice of Android issue #1545.

## Failing-before reproduction

The audited module has no unit tests (`:features:pdf:testReleaseUnitTest` reports `NO-SOURCE`). Regression-first additions initially fail to compile because journal/session/restore boundaries do not exist. Deterministic tests then model:

1. Persist a mutation to the journal but withhold the debounced repository save.
2. Destroy and recreate the session over the same private directory.
3. Require the dirty generation to restore and replay.

They also seed a valid current snapshot plus a partially malformed candidate; the base clear-then-decode path leaves a partial/empty document, while the fixed path must retain or reconstruct the last-known-good state.

## Minimal fix

- Listen to PDF SDK create/update/remove/z-order mutations and capture complete snapshots.
- Synchronously write a bounded, checksummed, versioned primary/backup sidecar before the existing debounced repository save.
- Use one debounce queue per PDF and preserve descriptor identity/index.
- Restore a dirty generation before the first repository emission and mark it clean only on equivalent acknowledgement.
- Validate complete current and candidate snapshots before destructive replacement; roll back a partial candidate.
- Distinguish absent input from explicit empty input and clean private sidecars on logout/account deletion.
- Preserve Room schema, wire models, stable IDs, and API paths.

## Recorded local checks

- PASS: PDF regression suite, 18/18, covering restart, stale emissions, failed/interrupted writes, backup recovery, corrupt evidence, per-PDF debounce, safe replacement, absent-versus-empty, and index preservation.
- PASS: auth cleanup suite, 5/5.
- PASS: `:features:pdf:check :common:auth:check spotlessCheck`.
- PASS: `:app:assembleRelease` (1,200 tasks).
- PASS: clean merge trees against RC-0001/0002/0003.
- PASS: combined RC-0002 + RC-0004 focused integration, 18 PDF + 5 auth + 5 sync tests.

These are local Windows-hosted JVM/fake/Gradle and unsigned assembly results. No licensed runtime, hosted Actions, emulator, physical-device, power-loss, signed, store, server, or production result is claimed.

The 2026-07-28 delivery refresh reconfirmed the unchanged target and zero-overlap PR set. The exact clean head passed 349/349 focused tasks with 18/18 PDF tests, the combined PDF/auth/format gate with 23/23 emitted tests, and a fresh unsigned app release assembly. This is local regression/build evidence only; the licensed-device, process-kill, low/disk-full storage, power-loss, server-conflict, privacy, rollback, and hosted gates below remain open.

## Overlap and disposition

Android PR #1548 at `8523d93c0f05376b30113a2b24c1f7bbccc30aa0` has zero file/root overlap and remains separate.

RC-0004 is file-disjoint from RC-0001/0002/0003 and should remain its own PR. RC-0002 is still needed to make replay durable through Room/network conflict and retry. Do not combine this root with the verification stack.

## Migration, recovery, and rollback

- No Room migration; the additive sidecar is created only after a future annotation mutation.
- A valid backup recovers an interrupted/corrupt primary; corrupt generations are retained as evidence and never treated as content.
- An explicit empty snapshot clears its addressed PDF; absence performs no clear.
- Existing lost annotations cannot be reconstructed without a trusted backup/server copy.
- An old binary ignores dirty sidecars. Safe rollback first replays every dirty generation into the existing repository and proves equivalence; never delete sidecars to make rollback pass.

## Security, privacy, and content rights

Sidecars remain in the app sandbox under `noBackupFilesDir`, use hashed filenames, bound decoding, and do not log payloads/raw IDs. They are checksummed but not newly encrypted; device-compromise encryption is a separate design. No content, translation, lesson, PDF/video asset, Bible/EGW material, credential, signing, or deployment file changes.

## Dependency order and draft blockers

Review independently after the higher-readiness Android roots, then retest in the final RC-0002 composition. Keep the PR draft until production-licensed devices cover annotation create/update/remove/z-order, final deletion, multiple/unloaded PDFs, lifecycle/process kill, offline relaunch, low/disk-full storage, corruption/rollback, logout/account deletion, vendor filesystem/power-loss behavior, and required hosted checks. Confirm server conflict semantics with an authorized nonproduction account.

