### PR TITLE
fix(block-kit): keep highlighted Bible links clickable

### DIFF
--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
@@ -109,6 +109,9 @@ import org.commonmark.parser.Parser
 internal const val TAG_URL = "url"
 internal const val TAG_IMAGE_URL = "imageUrl"
 
+internal fun AnnotatedString.urlAt(position: Int): String? =
+    getStringAnnotations(TAG_URL, position, position).firstOrNull()?.item
+
 @Composable
 fun MarkdownText(
     markdownText: String,
@@ -149,14 +152,7 @@ fun MarkdownText(
                 detectTapGestures { offset ->
                     layoutResult.value?.let { layoutResult ->
                         val position = layoutResult.getOffsetForPosition(offset)
-                        styledText
-                            .getStringAnnotations(position, position)
-                            .firstOrNull()
-                            ?.let { annotation ->
-                                if (annotation.tag == TAG_URL) {
-                                    onHandleUri(annotation.item)
-                                }
-                            }
+                        styledText.urlAt(position)?.let(onHandleUri)
                     }
                 }
             }

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/input/MarkdownTextInput.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/input/MarkdownTextInput.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
-import io.adventech.blockkit.ui.TAG_URL
+import io.adventech.blockkit.ui.urlAt
 import me.saket.extendedspans.ExtendedSpans
 import me.saket.extendedspans.drawBehind
 
@@ -88,14 +88,7 @@ internal fun MarkdownTextInput(
                             val offset = interaction.press.pressPosition
                             val position = layoutResult.getOffsetForPosition(offset)
 
-                            styledText
-                                .getStringAnnotations(position, position)
-                                .firstOrNull()
-                                ?.let { annotation ->
-                                    if (annotation.tag == TAG_URL) {
-                                        onHandleUri(annotation.item)
-                                    }
-                                }
+                            styledText.urlAt(position)?.let(onHandleUri)
                         }
                     }
                 }

--- a/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/MarkdownLinkClickTest.kt
+++ b/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/MarkdownLinkClickTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.adventech.blockkit.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.unit.sp
+import me.saket.extendedspans.ExtendedSpans
+import me.saket.extendedspans.RoundedCornerSpanPainter
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class MarkdownLinkClickTest {
+
+    @Test
+    fun `highlight decoration before URL does not block link click`() {
+        val uri = "ss-bible://John.3.16"
+        val source = buildAnnotatedString {
+            append("John 3:16")
+            addStyle(SpanStyle(background = Color.Yellow), 0, length)
+            addStringAnnotation(TAG_URL, uri, 0, length)
+        }
+        val text = ExtendedSpans(
+            RoundedCornerSpanPainter(
+                cornerRadius = 6.sp,
+                padding = RoundedCornerSpanPainter.TextPaddingValues(horizontal = 4.sp),
+                topMargin = 2.sp,
+                bottomMargin = 2.sp,
+                stroke = RoundedCornerSpanPainter.Stroke(color = Color.Transparent),
+            )
+        ).extend(source)
+
+        text.getStringAnnotations(4, 4).first().tag shouldBeEqualTo "rounded_corner_span"
+        text.urlAt(4) shouldBeEqualTo uri
+    }
+}


### PR DESCRIPTION
## Audit root

- Audit ID: `ADV-2026-0023` / `RC-0023`
- Related issue: #1547
- Base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Head: `13b6247f4d98a6a76a2faf4f8c01424f9dfd4292`
- Scope: one commit, one root, 3 files

## Why

Compose BlockKit inserts a visual `rounded_corner_span` annotation before the preserved semantic `url` annotation for highlighted text. The tap path selected the first annotation at the offset and only afterward checked its tag, so the decoration shadowed highlighted Bible links and navigation was ignored.

## Minimal fix

Query the semantic `url` tag directly through one shared `AnnotatedString.urlAt(position)` resolver and use it in both selectable and non-selectable Markdown rendering. No parser, persistence, schema, URI destination, content, dependency, or deployment changes are included.

## Regression evidence

- Expected RED: the focused highlighted-link regression could not compile before the semantic resolver existed.
- PASS: focused regression, 1/1.
- PASS: `:libraries:block-kit:ui:check spotlessCheck`; 20/20 BlockKit tests, zero failures/errors/skips.
- PASS: `:app:bundleRelease` (1,200 Gradle tasks).
- PASS: clean integration with the paragraph persistence reducer.
- PASS: exact diff/ancestry checks and clean worktree.
- PASS: equal test-only API 35 real-Compose center-touch differential: exact base passes the unhighlighted-link and non-link controls but fails only the highlighted exact-URI callback (2/3); the exact PR head passes all three (3/3). The byte-identical harness refs are unpushed and excluded from delivery/milestone credit; canonical public-safe log SHA-256 is 9AAF24D3664008210E644FFA97B94E88B3D974CD25798CBADF8D706102AD17EB.

Local environment: checked-in Gradle 9.4.0 wrapper, Temurin 21.0.11, Android SDK/API 36, plus a local API 35 AOSP emulator for the bounded synthetic touch differential above. Hosted CI, API 24/API 36, physical-device, broader selection/RTL, TalkBack, keyboard/D-pad, signed build, release, and deployment results are not claimed.

## Overlap and compatibility

PR #1548 changes only screen timeout behavior. Drafts #1549-#1551 address separate persistence/migration/PDF roots. This PR has no file/root overlap with any of them and all merge-tree checks pass. The contrast root is intentionally separate and merges cleanly.

No data or wire migration is required. Existing URI values and callbacks remain unchanged. Reverting this commit is format-compatible but restores the click defect.

The published commit uses the account's GitHub noreply identity; its tested source tree, parent, message, and stable patch ID are unchanged from the recorded local evidence.

Keep this PR in draft until hosted Android CI and the minimum/current API, selection gesture, RTL, TalkBack, keyboard/D-pad, and release-equivalent device matrix pass. Do not merge or close #1547 from local evidence alone.