### PR TITLE
fix(block-kit): preserve readable text in highlights

### DIFF
--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/MarkdownText.kt
@@ -72,7 +72,7 @@ import io.adventech.blockkit.parser.span.Span
 import io.adventech.blockkit.parser.span.TextAttributes
 import io.adventech.blockkit.ui.color.AttributedTextColorOverride
 import io.adventech.blockkit.ui.color.parse
-import io.adventech.blockkit.ui.color.toColor
+import io.adventech.blockkit.ui.color.toHighlightSpanStyle
 import io.adventech.blockkit.ui.style.BlockStyleTemplate
 import io.adventech.blockkit.ui.style.StyleTemplate
 import io.adventech.blockkit.ui.style.Styler
@@ -233,12 +233,8 @@ internal fun rememberMarkdownText(
                 // Ensure indices are within valid bounds of the text.
                 val textLength = this.length
                 if (highlight.startIndex in 0 until textLength && highlight.endIndex in (highlight.startIndex + 1)..textLength) {
-                    val color = highlight.color.toColor()
                     addStyle(
-                        style = SpanStyle(
-                            background = color.copy(alpha = 0.15f),
-                            color = color,
-                        ),
+                        style = highlight.color.toHighlightSpanStyle(),
                         start = highlight.startIndex,
                         end = highlight.endIndex,
                     )

--- a/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/color/Color.kt
+++ b/libraries/block-kit/ui/src/main/kotlin/io/adventech/blockkit/ui/color/Color.kt
@@ -23,6 +23,7 @@
 package io.adventech.blockkit.ui.color
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
 import io.adventech.blockkit.model.input.HighlightColor
 
 val Color.Companion.Primary: Color
@@ -138,3 +139,6 @@ fun HighlightColor.toColor(): Color = when (this) {
     HighlightColor.RED -> Color(0xFFEC5252)
     HighlightColor.UNKNOWN -> Color.Transparent
 }
+
+internal fun HighlightColor.toHighlightSpanStyle(): SpanStyle =
+    SpanStyle(background = toColor().copy(alpha = 0.15f))

--- a/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/color/HighlightContrastTest.kt
+++ b/libraries/block-kit/ui/src/test/kotlin/io/adventech/blockkit/ui/color/HighlightContrastTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025. Adventech <info@adventech.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.adventech.blockkit.ui.color
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.takeOrElse
+import io.adventech.blockkit.model.input.HighlightColor
+import java.util.Locale
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HighlightContrastTest {
+
+    @Test
+    fun `highlight text meets WCAG AA in every reader theme`() {
+        val failures = buildList {
+            readerPalettes.forEach { palette ->
+                highlightColors.forEach { highlightColor ->
+                    val style = highlightColor.toHighlightSpanStyle()
+                    val effectiveBackground = style.background.compositeOver(palette.background)
+                    val effectiveForeground = style.color.takeOrElse { palette.foreground }
+                    val contrast = contrastRatio(effectiveForeground, effectiveBackground)
+
+                    if (contrast < MinimumContrast) {
+                        add("${palette.name}/${highlightColor.name}: ${String.format(Locale.ROOT, "%.2f", contrast)}:1")
+                    }
+                }
+            }
+        }
+
+        assertTrue(
+            "Expected WCAG AA contrast of at least $MinimumContrast:1, failures:\n${failures.joinToString("\n")}",
+            failures.isEmpty(),
+        )
+    }
+
+    private fun contrastRatio(foreground: Color, background: Color): Float {
+        val foregroundLuminance = foreground.luminance()
+        val backgroundLuminance = background.luminance()
+        val lighter = maxOf(foregroundLuminance, backgroundLuminance)
+        val darker = minOf(foregroundLuminance, backgroundLuminance)
+        return (lighter + 0.05f) / (darker + 0.05f)
+    }
+
+    private data class ReaderPalette(
+        val name: String,
+        val background: Color,
+        val foreground: Color,
+    )
+
+    private companion object {
+        const val MinimumContrast = 4.5f
+
+        val highlightColors = HighlightColor.entries - HighlightColor.UNKNOWN
+
+        val readerPalettes = listOf(
+            ReaderPalette("Light", Color.White, Color.Primary950),
+            ReaderPalette("Sepia", Color.Sepia100, Color.Sepia400),
+            ReaderPalette("Dark", Color.Black, Color.Gray20),
+            ReaderPalette("Auto(light)", Color.White, Color.Primary950),
+            ReaderPalette("Auto(dark)", Color.Black, Color.Gray20),
+        )
+    }
+}


### PR DESCRIPTION
## Audit root

- Audit ID: `ADV-2026-0024` / `RC-0024`
- Related issue: #1449
- Base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Head: `bc1785e24cedc7cb20a463b8d817c5336eb8dfc3`
- Scope: one commit, one root, 3 files

## Why

Persisted highlight hues were applied as both the background and foreground. Across the seven production colors, normal text in Light, Sepia, and Auto-light measured only 1.44-3.06:1, below the 4.5:1 target. Dark mode happened to pass but still lost the selected semantic foreground.

## Minimal fix

Keep the existing stored color IDs, hue, and 15% background alpha, but leave `SpanStyle.color` unspecified so the already-selected theme/content foreground remains intact. No persistence, schema, parser, content, dependency, or deployment changes are included.

## Regression evidence

- Expected RED: the production-palette regression fails 1/1 on the audited base.
- PASS: focused contrast regression across all seven highlight colors and Light/Sepia/Dark/Auto states.
- PASS: `:libraries:block-kit:ui:check spotlessCheck`; 20/20 BlockKit tests, zero failures/errors/skips.
- PASS: `:app:bundleRelease` (1,200 Gradle tasks).
- PASS: combined integration with paragraph persistence and highlighted-link roots, 27/27.
- PASS: exact diff/ancestry checks and clean worktree.
- NON-COUNTING device limitation: an equal API 35 rendered-pixel harness compiled and packaged on exact base/fix children, but three clean base attempts failed explicit white/black calibration despite exact 1:1 contained sRGB/opaque geometry. This emulator capture path is final NO-GO; the fixed APK was not run after calibration failed and no device/M6 result is claimed. Public-safe failure-log SHA-256: 5CD4DAE73CE09A76D25880033226D48276AC157C8360F2824DC9660910BADB7C.

Preserving the foreground yields at least 9.10:1 in the production matrix. The untouched base and head both show Windows font/layout drift in the Roborazzi environment, so no golden was rewritten; Linux deterministic golden validation remains required.

Local environment: checked-in Gradle 9.4.0 wrapper, Temurin 21.0.11, Android SDK/API 36, plus the rejected local API 35 AOSP capture attempt above. Hosted CI, Linux golden, independently validated emulator/physical-device, accessibility-service, signed build, release, and deployment results are not claimed.

## Linux/WSL execution evidence (2026-07-30)

- The corrected, non-recording Roborazzi command reaches BlockKit's release tests and verification tasks on exact audited refs.
- The ADV-0024 contrast regression passes, and its highlight rendering differs from the untouched base, proving the intended path was exercised.
- The untouched base also differs from all 17 committed images and matches the ADV-0069 replay 17/17. This confirms systematic renderer/font drift in this WSL environment rather than an ADV-0024 product failure.
- No golden image was recorded or changed. WSL is not accepted as golden authority.
- Hosted acceptance must pin the Ubuntu image, JDK, locale, timezone, font inventory (or a container), then accept only the intended highlight delta after maintainer visual review.
- Public-safe canonical log SHA-256: AAF13A731A990565DCABA0DE01F2219ED6A0D1387D41359D242A61561D07EB8F.
## Overlap and compatibility

PR #1548 changes only screen timeout behavior. Drafts #1549-#1552 address separate roots. This PR shares only `MarkdownText.kt` with #1552, edits a separate concern, and merge-tree verification is clean; keep the roots separate and rebase/rerun this PR if #1552 lands first.

No data migration is required and existing stored color IDs remain stable. Reverting this commit is storage-compatible but restores the contrast defect.

The published commit uses the account's GitHub noreply identity; its tested source tree, parent, message, and stable patch ID are unchanged from the recorded local evidence.

Keep this PR in draft until hosted Android CI, Linux golden review, and minimum/current API physical-device visual and accessibility matrices pass. Do not merge or close #1449 from local evidence alone.