### PR TITLE
ci(android): run push quality gates on pull requests

### DIFF
--- a/.github/scripts/verify_pull_request_ci.py
+++ b/.github/scripts/verify_pull_request_ci.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify that pull requests run the same quality gates as pushes."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PULL_REQUEST_WORKFLOW = ROOT / ".github" / "workflows" / "pull_request.yml"
+PUSH_WORKFLOW = ROOT / ".github" / "workflows" / "on_push.yml"
+
+
+def yaml_block(text: str, key: str, indent: int) -> str:
+    """Return a simple indentation-delimited YAML mapping block."""
+    lines = text.splitlines()
+    header = f"{' ' * indent}{key}:"
+
+    try:
+        start = lines.index(header)
+    except ValueError as error:
+        raise AssertionError(f"Missing YAML block: {header}") from error
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent <= indent:
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def gradle_quality_commands(job: str) -> set[str]:
+    commands = set()
+    for line in job.splitlines():
+        match = re.match(r"\s*run\s*:\s*(.+?)\s*$", line)
+        if not match:
+            continue
+        command = match.group(1)
+        if command == "./gradlew check" or "testDebugUnitTest" in command:
+            commands.add(command)
+    return commands
+
+
+def main() -> int:
+    pull_request = PULL_REQUEST_WORKFLOW.read_text(encoding="utf-8")
+    push = PUSH_WORKFLOW.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    def require(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    require("pull_request_target:" not in pull_request, "PR CI must not use pull_request_target")
+
+    try:
+        permissions = yaml_block(pull_request, "permissions", 0)
+    except AssertionError as error:
+        failures.append(str(error))
+        permissions = ""
+
+    require("contents: read" in permissions, "PR CI must explicitly grant only contents: read")
+    require(": write" not in permissions, "PR CI must not grant write permissions")
+
+    try:
+        quality = yaml_block(pull_request, "quality", 2)
+    except AssertionError as error:
+        failures.append(str(error))
+        quality = ""
+
+    try:
+        release = yaml_block(pull_request, "testing", 2)
+    except AssertionError as error:
+        failures.append(str(error))
+        release = ""
+
+    try:
+        push_build = yaml_block(push, "build", 2)
+    except AssertionError as error:
+        failures.append(str(error))
+        push_build = ""
+
+    require("runs-on: ubuntu-latest" in quality, "PR quality gates must run on Linux")
+    require("timeout-minutes: 30" in quality, "PR quality job must have a bounded timeout")
+    require("uses: actions/checkout@v6" in quality, "PR quality job must check out the repository")
+    require("persist-credentials: false" in quality, "PR quality checkout must not persist credentials")
+    require("uses: actions/setup-java@v5" in quality, "PR quality job must install the supported JDK")
+    require("java-version: '21'" in quality, "PR quality job must use JDK 21")
+    require("uses: gradle/actions/setup-gradle@v5" in quality, "PR quality job must configure Gradle caching")
+    require(
+        "python3 .github/scripts/verify_pull_request_ci.py" in quality,
+        "PR quality job must enforce this workflow policy",
+    )
+
+    require("${{ secrets." not in quality, "PR quality job must not reference repository secrets")
+    require("decrypt-secrets" not in quality, "PR quality job must not decrypt release secrets")
+    require("ENCRYPT_KEY" not in quality, "PR quality job must not request the release encryption key")
+
+    push_quality_commands = gradle_quality_commands(push_build)
+    pull_request_quality_commands = gradle_quality_commands(quality)
+    require(
+        push_quality_commands == pull_request_quality_commands,
+        "PR quality Gradle commands must exactly match push quality commands "
+        f"(push={sorted(push_quality_commands)}, PR={sorted(pull_request_quality_commands)})",
+    )
+    require(
+        push_quality_commands
+        == {
+            "./gradlew check",
+            "./gradlew testDebugUnitTest -Proborazzi.test.verify=true",
+        },
+        "Push quality command detection changed; review parity policy before updating it",
+    )
+
+    require("runs-on: macos-latest" in release, "Existing release-build lane must remain on macOS")
+    require(
+        "./gradlew app:bundleRelease --stacktrace" in release,
+        "Existing PR release bundle gate must be preserved",
+    )
+
+    if failures:
+        print("Pull request CI policy violations:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Pull request CI policy verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,40 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
+  quality:
+    name: Code Quality and Screenshot Tests
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Verify pull request CI policy
+        run: python3 .github/scripts/verify_pull_request_ci.py
+
+      - name: Run Code Quality Checks
+        run: ./gradlew check
+
+      - name: Screenshot Tests
+        run: ./gradlew testDebugUnitTest -Proborazzi.test.verify=true
+
   testing:
     name: Test Suite [Instrumented]
 


### PR DESCRIPTION
> **Dependency/rebase notice (audit update):** Keep this draft unmerged. Android reproducibility draft #1556 must land first. The corrected one-root replay is parked on the fork-only branch `staging/adv-2026-0051-after-0058` at `b968dcf0e19c9a94851cd94f48b863c5fc1a2330`; no upstream PR was opened for that dependent head because it would currently bundle #1556. After #1556 lands, replay onto the actual landed SHA, rerun the full gate, and update this draft with an exact lease. Current hosted runs are `action_required` with zero jobs, so no hosted pass is claimed.
## Audit root

- Audit ID: `ADV-2026-0051` / `RC-0051`
- Base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Head: `ddd5a410a86d709eb90d002dbbc3bbc3411add41`
- Scope: one commit, one root, 2 files, +171

## Why

Pull requests currently run a macOS release bundle but omit the two quality commands required after push: `./gradlew check` and `./gradlew testDebugUnitTest -Proborazzi.test.verify=true`. A PR can therefore appear green and fail immediately after merge on compilation, lint, formatting, unit, or configured screenshot checks.

## Minimal fix

Add a bounded, secret-free Ubuntu quality job with `contents: read`, non-persisting checkout, the repository's JDK 21/Gradle setup, a dependency-free fail-closed policy, and the exact two push-quality commands. The existing macOS release-bundle job is preserved byte-for-byte.

No application code, content, schema, cache, persistence, signing, store, release artifact, or deployment behavior changes are included.

## Regression evidence

- Expected RED: the policy exits 1 on the audited base and reports the missing least-privilege job and parity commands.
- PASS: policy and Actionlint 1.7.12.
- PASS: full Gradle `check`, 2,681 tasks.
- PASS: configured unit lane, 1,029 tasks; app 17/17 and app-tv 22/22.
- PASS: preserved `app:bundleRelease`, 1,200 tasks.
- PASS: exact diff/ancestry and clean-worktree checks.

The published commit uses the account's GitHub noreply identity while preserving the tested tree, parent, message, dates, and stable patch ID.

## Overlap and gates

Open Android PRs #1548-#1553 have zero changed-file/root overlap; all six merge-tree checks pass. ADV-0054 changes the push secret boundary and remains a separate, file-disjoint PR. ADV-0069 owns complete canonical Roborazzi coverage and must also remain separate.

Keep this PR in draft until first-time-fork approval, the exact hosted Ubuntu quality job, the preserved hosted macOS release-bundle job, privacy/log review, timeout observation, and required-check transition review pass. No merge, release, or deployment is authorized by local evidence.