### PR TITLE
ci(android): keep release secrets out of push checks

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -19,11 +19,6 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
 
-      - name: Decrypt secrets
-        run: ./release/decrypt-secrets.sh
-        env:
-          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
-
       - name: Run Code Quality Checks
         run: ./gradlew check
 

--- a/audit-tests/workflow-secret-boundary.test.cjs
+++ b/audit-tests/workflow-secret-boundary.test.cjs
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+const test = require("node:test")
+
+const repositoryRoot = path.resolve(__dirname, "..")
+const readWorkflow = (name) =>
+    fs.readFileSync(
+        path.join(repositoryRoot, ".github", "workflows", name),
+        "utf8",
+    )
+
+test("ordinary push CI does not decrypt or receive release secrets", () => {
+    const source = readWorkflow("on_push.yml")
+
+    assert.doesNotMatch(source, /decrypt-secrets\.sh/)
+    assert.doesNotMatch(source, /ENCRYPT_KEY/)
+    assert.doesNotMatch(source, /\$\{\{\s*secrets\./)
+})
+
+test("ordinary push CI retains its quality and screenshot gates", () => {
+    const source = readWorkflow("on_push.yml")
+
+    assert.match(source, /\.\/gradlew check/)
+    assert.match(
+        source,
+        /\.\/gradlew testDebugUnitTest -Proborazzi\.test\.verify=true/,
+    )
+})
+
+test("release material remains scoped to publishing workflows", () => {
+    for (const workflow of ["on_publish.yml", "release.yml"]) {
+        const source = readWorkflow(workflow)
+        assert.match(source, /decrypt-secrets\.sh/, workflow)
+        assert.match(source, /ENCRYPT_KEY:\s*\$\{\{ secrets\.ENCRYPT_KEY \}\}/, workflow)
+    }
+})


### PR DESCRIPTION
Audit: `ADV-2026-0054` / `RC-0054`

## Root cause

The ordinary push workflow materializes release/store configuration with `secrets.ENCRYPT_KEY` before running public quality tasks. Those tasks complete without release material, so ordinary CI unnecessarily crosses the release-secret boundary.

## Regression-first fix

- Audited base: `55405f66a8c555047dc0035747acdcaa371d59fa`
- Failing regression commit: `2958523bd571e56530f0e8a7c04b8e9725d476a8`
- Fix/head: `ef53825164d6ca887ac7fcad329b966f14595df8`
- Shape: two commits for one root; 2 files, +37/-5

The regression reports 2 pass / 1 fail on the base and 3/3 at the head. The fix removes only the five-line decrypt step from ordinary push CI; it does not read, rewrite, or publish encrypted material.

## Recorded evidence

- Secret-boundary regression: 3/3
- Actionlint 1.7.12: pass
- Secretless Gradle `check`: 2,681 tasks, pass
- No decrypted release files before or after validation
- Zero changed-path/root overlap with open Android PRs #1548-#1554
- Clean composition with the separate PR-quality root in #1554

No application/content/schema/signing-material change, release, deployment, or protected-branch write is included.

## Draft gates

A pull-request workflow cannot exercise `.github/workflows/on_push.yml`. Keep this draft until a maintainer runs the exact head on an authorized nonproduction upstream validation branch and confirms that hosted Ubuntu completes the quality commands without requesting or materializing release secrets. Canonical Linux screenshot review and the protected release boundary remain separate roots. Do not use `main`/`develop` release automation as a dry run because it can upload to internal Play tracks.

Migration/recovery: none; stored data and artifact formats are unchanged. Rollback should not restore decryption to ordinary CI—if a quality task needs configuration, use a synthetic non-secret fixture.