### PR TITLE
ci: pin and least-privilege Android workflows

### DIFF
--- a/.github/scripts/validate_actions_policy.py
+++ b/.github/scripts/validate_actions_policy.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Fail closed when the repository's GitHub Actions trust boundary regresses."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+# Each commit was resolved from the named upstream tag and its action manifest
+# was reviewed at this exact commit before it was added here.
+APPROVED_ACTIONS = {
+    "actions/labeler": "b8dd2d9be0f68b860e7dae5dae7d772984eacd6d",  # v6
+    "actions/checkout": "d23441a48e516b6c34aea4fa41551a30e30af803",  # v6
+    "actions/setup-java": "03ad4de0992f5dab5e18fcb136590ce7c4a0ac95",  # v5
+    "gradle/actions/setup-gradle": "0723195856401067f7a2779048b490ace7a47d7c",  # v5.0.2
+    "actions/upload-release-asset": "e8f9f06c4b078e705bd2ea027f0926603fc9b4d5",  # v1.0.2
+    "release-drafter/release-drafter": "eada3c96a64734dd381cfbda23511034e328ddb0",  # v7
+    "r0adkll/upload-google-play": "935ef9c68bb393a8e6116b1575626a7f5be3a7fb",  # v1.1.3
+}
+
+EXPECTED_ACTION_COUNTS = Counter(
+    {
+        "actions/labeler": 1,
+        "actions/checkout": 4,
+        "actions/setup-java": 4,
+        "gradle/actions/setup-gradle": 1,
+        "actions/upload-release-asset": 1,
+        "release-drafter/release-drafter": 1,
+        "r0adkll/upload-google-play": 2,
+    }
+)
+
+EXPECTED_WORKFLOWS = {
+    "labels.yml",
+    "on_publish.yml",
+    "on_push.yml",
+    "pull_request.yml",
+    "release.yml",
+}
+
+EXPECTED_WRITES = {
+    "labels.yml": Counter({"pull-requests": 1}),
+    "on_publish.yml": Counter({"contents": 1}),
+    "on_push.yml": Counter(),
+    "pull_request.yml": Counter(),
+    "release.yml": Counter({"contents": 1}),
+}
+
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+WRITE_RE = re.compile(r"^\s+([a-z-]+):\s*write\s*(?:#.*)?$")
+
+
+def workflow_sources() -> dict[str, str]:
+    paths = sorted((*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")))
+    return {path.name: path.read_text(encoding="utf-8").replace("\r\n", "\n") for path in paths}
+
+
+def external_uses(text: str) -> list[tuple[int, str, str]]:
+    uses: list[tuple[int, str, str]] = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        match = USES_RE.match(line)
+        if not match:
+            continue
+        reference = match.group(1)
+        if reference.startswith("./") or reference.startswith("docker://"):
+            continue
+        if "@" not in reference:
+            uses.append((line_number, reference, ""))
+            continue
+        action, revision = reference.rsplit("@", 1)
+        uses.append((line_number, action, revision))
+    return uses
+
+
+def immutable_action_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    counts: Counter[str] = Counter()
+    for name, source in sources.items():
+        for line_number, action, revision in external_uses(source):
+            counts[action] += 1
+            approved = APPROVED_ACTIONS.get(action)
+            if approved is None:
+                errors.append(f"{name}:{line_number}: unreviewed external action {action}")
+            elif not FULL_SHA_RE.fullmatch(revision):
+                errors.append(f"{name}:{line_number}: mutable action ref {action}@{revision}")
+            elif revision != approved:
+                errors.append(f"{name}:{line_number}: unapproved commit for {action}")
+    if counts != EXPECTED_ACTION_COUNTS:
+        errors.append(f"external action inventory changed: expected {EXPECTED_ACTION_COUNTS}, got {counts}")
+    return errors
+
+
+def permission_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    top_level = re.compile(r"(?m)^permissions:\s*\n  contents:\s*read\s*$")
+    for name, source in sources.items():
+        if not top_level.search(source):
+            errors.append(f"{name}: missing top-level contents: read permission")
+        if re.search(r"(?m)^permissions:\s*(?:write-all|read-all)\s*$", source):
+            errors.append(f"{name}: broad permission preset is forbidden")
+        writes = Counter(
+            match.group(1)
+            for line in source.splitlines()
+            if (match := WRITE_RE.match(line))
+        )
+        if writes != EXPECTED_WRITES[name]:
+            errors.append(f"{name}: expected write grants {EXPECTED_WRITES[name]}, got {writes}")
+
+    required_job_scopes = {
+        "labels.yml": (
+            "  label:\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write"
+        ),
+        "on_publish.yml": "  build:\n    permissions:\n      contents: write",
+        "release.yml": (
+            "  update_draft_release:\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "      pull-requests: read"
+        ),
+    }
+    for name, snippet in required_job_scopes.items():
+        if snippet not in sources[name]:
+            errors.append(f"{name}: missing exact least-privilege job scope")
+    return errors
+
+
+def checkout_credential_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    for name, source in sources.items():
+        lines = source.splitlines()
+        for index, line in enumerate(lines):
+            if "uses: actions/checkout@" not in line or line.lstrip().startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            block: list[str] = []
+            for following in lines[index + 1 :]:
+                stripped = following.lstrip()
+                following_indent = len(following) - len(stripped)
+                if stripped.startswith("-") and following_indent < indent:
+                    break
+                block.append(following)
+            if not any(re.match(r"^\s+persist-credentials:\s*false\s*$", item) for item in block):
+                errors.append(f"{name}:{index + 1}: checkout credentials would persist")
+    return errors
+
+
+def release_concurrency_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    expected = {
+        "on_publish.yml": (
+            "concurrency:\n"
+            "  group: android-release-assets\n"
+            "  cancel-in-progress: false"
+        ),
+        "release.yml": (
+            "concurrency:\n"
+            "  group: android-google-play-internal\n"
+            "  cancel-in-progress: false"
+        ),
+    }
+    for name, snippet in expected.items():
+        if snippet not in sources[name]:
+            errors.append(f"{name}: missing non-cancelling release concurrency")
+        if re.search(r"(?m)^\s*cancel-in-progress:\s*true\s*$", sources[name]):
+            errors.append(f"{name}: a running release must never be cancelled")
+    return errors
+
+
+def release_boundary_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    publish = sources["on_publish.yml"]
+    release = sources["release.yml"]
+    if 'types: ["published"]' not in publish:
+        errors.append("on_publish.yml: release asset upload is not limited to published releases")
+    if "      - develop\n      - main" not in release:
+        errors.append("release.yml: push trigger is not limited to develop/main")
+    guard = "if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'"
+    if guard not in release:
+        errors.append("release.yml: Play upload job lacks a defensive full-ref guard")
+    return errors
+
+
+def policy_execution_errors(sources: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    command = "run: python3 .github/scripts/validate_actions_policy.py"
+    for name in ("on_push.yml", "pull_request.yml"):
+        if command not in sources[name]:
+            errors.append(f"{name}: policy regression script is not executed")
+    return errors
+
+
+def main() -> int:
+    sources = workflow_sources()
+    if set(sources) != EXPECTED_WORKFLOWS:
+        print(
+            f"workflow inventory changed: expected {sorted(EXPECTED_WORKFLOWS)}, "
+            f"got {sorted(sources)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    groups = {
+        "immutable reviewed action refs": immutable_action_errors(sources),
+        "explicit least token permissions": permission_errors(sources),
+        "non-persistent checkout credentials": checkout_credential_errors(sources),
+        "non-cancelling release concurrency": release_concurrency_errors(sources),
+        "release event and ref boundaries": release_boundary_errors(sources),
+        "policy executes in ordinary CI": policy_execution_errors(sources),
+    }
+
+    failures = 0
+    for name, errors in groups.items():
+        status = "PASS" if not errors else "FAIL"
+        print(f"{status}: {name}")
+        for error in errors:
+            print(f"  - {error}")
+        failures += bool(errors)
+
+    print(f"tests {len(groups)}")
+    print(f"pass {len(groups) - failures}")
+    print(f"fail {failures}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,13 +2,19 @@
 name: Labeler
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labels_config.yml"

--- a/.github/workflows/on_publish.yml
+++ b/.github/workflows/on_publish.yml
@@ -4,17 +4,31 @@ on:
   release:
     types: ["published"]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: android-release-assets
+  cancel-in-progress: false
+
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Actions policy
+        run: python3 .github/scripts/validate_actions_policy.py
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -31,7 +45,7 @@ jobs:
         run: ./gradlew app:assembleRelease --stacktrace
 
       - name: Upload APK
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -11,10 +14,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Actions policy
+        run: python3 .github/scripts/validate_actions_policy.py
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'zulu'
           java-version: '21'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     name: Test Suite [Instrumented]
@@ -18,16 +21,21 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Actions policy
+        run: python3 .github/scripts/validate_actions_policy.py
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
 #      - name: AVD cache
 #        uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,38 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: android-google-play-internal
+  cancel-in-progress: false
+
 jobs:
   update_draft_release:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: macos-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   submit-release:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     runs-on: macos-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Actions policy
+        run: python3 .github/scripts/validate_actions_policy.py
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -38,7 +54,7 @@ jobs:
         run: ./gradlew app:bundleRelease app-tv:bundleRelease --stacktrace
 
       - name: Publish to Internal track
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
         with:
           serviceAccountJson: release/play-account.json
           packageName: com.cryart.sabbathschool
@@ -49,7 +65,7 @@ jobs:
           mappingFile: app/build/outputs/mapping/release/mapping.txt
 
       - name: Publish to TV Internal track
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
         with:
           serviceAccountJson: release/play-account.json
           packageName: com.cryart.sabbathschool


### PR DESCRIPTION
> **DO NOT MERGE:** hosted fork/no-secret validation, protected-environment review, replay after #1556, and a non-production release/rollback rehearsal are still required.

## Root cause

The five Android workflows trusted mutable external-action refs, relied on implicit token permissions, and allowed checkout credentials to persist. The two release-writing paths also lacked explicit non-cancelling concurrency boundaries, and the Play job lacked a defensive full-ref guard.

This is the single action-provenance and workflow-trust-boundary root tracked as `ADV-2026-0033` / `RC-0033`. It is based on `main` at `55405f66a8c555047dc0035747acdcaa371d59fa`.

## Change

- Pin all 14 active external-action uses to reviewed full commit SHAs.
- Default every workflow token to `contents: read`, granting writes only to the jobs that label PRs or update releases.
- Set `persist-credentials: false` on all four checkouts.
- Serialize release-asset and Play submissions without cancelling a running release.
- Preserve the existing `main`/`develop` release behavior while adding a defensive full-ref guard.
- Add a fail-closed policy test that inventories every workflow/action and rejects mutable or unreviewed refs, excess permissions, persistent credentials, unsafe release boundaries, or removal of the policy from ordinary CI.

No application code, content, signing material, release credential, persistence format, or user data changes.

## Red/green evidence

- Red commit `de799a5998d1a926e0fd68cf337f6f3bc739d3d6`: expected failure, **0/6** policy groups passed.
- Green commit `2ad6104c258e115b17ab90af118cd07a7773be14`: **6/6** policy groups passed; tree `eee2a593ae127ac2036c136f53256f806cbc9949`.
- Immutable action inventory: **14/14** exact allowlisted commits.
- Actionlint 1.7.12: PASS, zero diagnostics across **5/5** workflows.
- Independent js-yaml 4.1.0 parse: PASS, **5/5** workflow mappings.
- Complete Gradle check on the byte-identical green tree: PASS, **2,681/2,681** tasks in 4m41s; zero lint errors and 22 inherited warnings.
- Release bundle graph: PASS under `--dry-run`; both signing tasks were present and skipped.
- Diff/ancestry/path/identity checks: PASS; exactly two noreply-authored commits, six expected files, `+306/-16`, and a clean worktree.

No signing, decryption, artifact upload, release, Play submission, deployment, or workflow dispatch was performed.

## Version decision

`actions/checkout` remains on the reviewed immutable v6 commit `d23441a48e516b6c34aea4fa41551a30e30af803`. It is an official signed Node 24 revision and is the version exercised by the complete tested tree. Moving to v7.0.1 adds behavior and dependency changes and should receive its own focused review rather than changing this root during publication.

`actions/upload-release-asset` remains an archived, unsigned Node 12 action. Its full-SHA pin contains provenance drift but does not modernize the runtime. Replacement is a separate behavior-tested root and remains a merge gate for release enablement.

## Open-PR overlap and required order

- #1548–#1553: no changed-path overlap with this branch.
- #1554: textually composes, but its new mutable action refs make this policy fail. Replay #1554 after #1556 and this root, review each added action commit, and update the inventory deliberately.
- #1555: overlaps `on_push.yml`; the merged tree is clean and both workflow policies pass.
- #1556: overlaps all five workflows and conflicts in two release workflows. **Land #1556 first, then replay this red/green pair and rerun the full matrix.** Do not merge this draft as-is over #1556.
- #1557: targets `develop`; preserve the documented order `#1557 -> corrected ADV-2026-0033 -> develop ADV-2026-0054 -> ADV-2026-0073`.

## Remaining safety gates

1. Rebase/replay after the accepted CI prerequisites, especially #1556, then rerun policy, actionlint, YAML, and the complete Gradle matrix.
2. Run GitHub-hosted Ubuntu/macOS checks first on a fork/no-secret event, then on an authorized same-repository no-deploy event.
3. Verify protected environments, required reviewers, branch restrictions, wait timers, and narrowly scoped short-lived deployment identities with a maintainer.
4. Replace the archived Node 12 release-asset action in its own tested PR.
5. Preserve the last-known-good signed artifact and Play/release state, then rehearse staging rollback and concurrent release behavior with no production write.
6. Review private dependency/security alerts and organization/branch rules through the authorized maintainer channel.

## Migration, recovery, and rollback

There is no persistence or schema migration. Operationally, release writers queue instead of racing, and later steps no longer inherit checkout credentials. Prefer a forward fix pinned to a newly reviewed commit. If concurrency/ref behavior needs correction, retain immutable pins, least permissions, and non-persistent credentials; never restore floating refs, implicit broad permissions, or persisted credentials.

