### PR TITLE
fix(i18n): correct awkward German translations for action labels

### DIFF
--- a/common/translations/src/main/res/values-de/strings.xml
+++ b/common/translations/src/main/res/values-de/strings.xml
@@ -108,10 +108,10 @@ Wir glauben wirklich, dass Gott die Erkenntnis der modernen Welt erhöht hat und
     <string name="ss_action_arrow_back">Pfeil zurück</string>
     <string name="ss_action_arrow_drop_down">Pfeil nach unten</string>
     <string name="ss_action_arrow_right">Pfeil rechts</string>
-    <string name="ss_action_close">Nah dran</string>
+    <string name="ss_action_close">Schließen</string>
     <string name="ss_action_selected">Ausgewählt</string>
-    <string name="ss_action_back">Der Rücken</string>
-    <string name="ss_action_open">Offen</string>
+    <string name="ss_action_back">Zurück</string>
+    <string name="ss_action_open">Öffnen</string>
     <string name="ss_action_rewind">Zurückspulen</string>
     <string name="ss_action_play_pause">Wiedergabe oder Pause</string>
     <string name="ss_action_playlist">Wiedergabeliste</string>


### PR DESCRIPTION
## Summary

Three German action labels read as literal Google-Translate output rather than idiomatic German UI conventions:

- `ss_action_close`: `Nah dran` (literal: *close to it*) → `Schließen` (close)
- `ss_action_back`:  `Der Rücken` (literal: *the back/anatomy*) → `Zurück` (back)
- `ss_action_open`:  `Offen` (adj: *open*) → `Öffnen` (verb: *open*)

These are accessibility content descriptions for media playback controls (see `ss_action_play_pause`, `ss_action_rewind`, `ss_action_forward`). The neighbouring labels use correct German verb forms (`Zurückspulen`, `Wiedergabe oder Pause`, `Wiedergabeliste`, `Nach vorne`), which makes the three literal translations stand out.

## Verification

- Source of truth for the keys: `common/translations/src/main/res/values/strings.xml` (EN)
- Old vs new on the four keys:
  - `Close` → `Schließen` ✓ (matches Android standard close affordance)
  - `Back` → `Zurück` ✓ (matches Android standard back affordance)
  - `Open` → `Öffnen` ✓ (verb form, parallel to `Schließen`)

No English source change. No string resource added or removed. Diff is three lines.